### PR TITLE
[Feature/#55] : 유저 정지 인프라 계층 구현

### DIFF
--- a/src/main/java/postman/bottler/user/domain/Ban.java
+++ b/src/main/java/postman/bottler/user/domain/Ban.java
@@ -1,0 +1,27 @@
+package postman.bottler.user.domain;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Ban {
+    private Long userId;
+
+    private LocalDateTime bannedAt;
+
+    private LocalDateTime unbansAt;
+
+    public static Ban create(Long userId, Long banDuration) {
+        return Ban.builder()
+                .userId(userId)
+                .bannedAt(LocalDateTime.now())
+                .unbansAt(LocalDateTime.now().plusDays(banDuration))
+                .build();
+    }
+
+    public void extendBanDuration(Long days) {
+        this.unbansAt = this.unbansAt.plusDays(days);
+    }
+}

--- a/src/main/java/postman/bottler/user/infra/BanRepositoryImpl.java
+++ b/src/main/java/postman/bottler/user/infra/BanRepositoryImpl.java
@@ -1,0 +1,47 @@
+package postman.bottler.user.infra;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import postman.bottler.user.domain.Ban;
+import postman.bottler.user.infra.entity.BanEntity;
+import postman.bottler.user.service.BanRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class BanRepositoryImpl implements BanRepository {
+    private final JpaBanRepository banRepository;
+
+    @Override
+    public Ban save(Ban ban) {
+        BanEntity entity = BanEntity.from(ban);
+        return banRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public Optional<Ban> findByUserId(Long userId) {
+        Optional<BanEntity> find = banRepository.findById(userId);
+        return find.map(BanEntity::toDomain);
+    }
+
+    @Override
+    public List<Ban> findUnbanned(LocalDateTime now) {
+        return banRepository.findByUnbansAtBefore(now).stream()
+                .map(BanEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void deleteBans(List<Ban> bans) {
+        banRepository.deleteAll(bans.stream()
+                .map(BanEntity::from)
+                .toList());
+    }
+
+    @Override
+    public Ban updateBan(Ban ban) {
+        return banRepository.save(BanEntity.from(ban)).toDomain();
+    }
+}

--- a/src/main/java/postman/bottler/user/infra/JpaBanRepository.java
+++ b/src/main/java/postman/bottler/user/infra/JpaBanRepository.java
@@ -1,0 +1,10 @@
+package postman.bottler.user.infra;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import postman.bottler.user.infra.entity.BanEntity;
+
+public interface JpaBanRepository extends JpaRepository<BanEntity, Long> {
+    List<BanEntity> findByUnbansAtBefore(LocalDateTime now);
+}

--- a/src/main/java/postman/bottler/user/infra/entity/BanEntity.java
+++ b/src/main/java/postman/bottler/user/infra/entity/BanEntity.java
@@ -1,0 +1,41 @@
+package postman.bottler.user.infra.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import postman.bottler.user.domain.Ban;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class BanEntity {
+    @Id
+    private Long userId;
+
+    private LocalDateTime bannedAt;
+
+    private LocalDateTime unbansAt;
+
+    public static BanEntity from(Ban ban) {
+        return BanEntity.builder()
+                .userId(ban.getUserId())
+                .bannedAt(ban.getBannedAt())
+                .unbansAt(ban.getUnbansAt())
+                .build();
+    }
+
+    public Ban toDomain() {
+        return Ban.builder()
+                .userId(userId)
+                .bannedAt(bannedAt)
+                .unbansAt(unbansAt)
+                .build();
+    }
+}

--- a/src/main/java/postman/bottler/user/service/BanRepository.java
+++ b/src/main/java/postman/bottler/user/service/BanRepository.java
@@ -1,0 +1,18 @@
+package postman.bottler.user.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import postman.bottler.user.domain.Ban;
+
+public interface BanRepository {
+    Ban save(Ban ban);
+
+    Optional<Ban> findByUserId(Long userId);
+
+    List<Ban> findUnbanned(LocalDateTime now);
+
+    void deleteBans(List<Ban> bans);
+
+    Ban updateBan(Ban ban);
+}

--- a/src/main/java/postman/bottler/user/service/BanService.java
+++ b/src/main/java/postman/bottler/user/service/BanService.java
@@ -1,0 +1,41 @@
+package postman.bottler.user.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import postman.bottler.user.domain.Ban;
+
+@RequiredArgsConstructor
+public class BanService {
+    private static final Long BAN_DAYS = 7L;
+
+    private final BanRepository banRepository;
+
+    public void unbanExpiredUsers() {
+        List<Ban> unbanned = banRepository.findUnbanned(LocalDateTime.now());
+        /** TODO 유저 정지 해제
+         *  Users users = userRepository.findWillBeUnbannedUser(unbanned);
+         *  users.unbanned();
+         */
+        /** TODO 유저 정보 업데이트
+         * userRepository.updateUsers(users);
+         */
+        banRepository.deleteBans(unbanned);
+    }
+
+    public void banUser(Long userId) {
+        /** TODO 유저 정지
+         * User user = userRepository.findById(userId);
+         * if (user.isBanned()) {
+         *     Ban ban = banRepository.findById(userId).orElseThrow()
+         *     ban.extendBanDuration(BAN_DAYS);
+         *     banRepository.update(ban);
+         *     return;
+         * }
+         * Ban ban = Ban.create(userId, BAN_DAYS);
+         * user.banned();
+         * banRepository.save(ban);
+         * userRepository.update(user);
+         */
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명 
유저 도메인 내 `Ban` 인프라 계층을 구현하였습니다.
- 유저 정지
- 유저 정지 해제

인프라 계층을 구현하였고, `BanService`는 정지, 정지 해제 로직을 주석으로 작성하여 추후 구현 시 참고할 수 있도록 하였습니다.


## 연결된 issue

close #55 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
