### PR TITLE
[Hotfix/#66] createdAt 관리 계층 수정

### DIFF
--- a/src/main/java/postman/bottler/complaint/controller/ComplaintController.java
+++ b/src/main/java/postman/bottler/complaint/controller/ComplaintController.java
@@ -53,7 +53,7 @@ public class ComplaintController {
         return ApiResponse.onCreateSuccess(response);
     }
 
-    @PostMapping("/keyword/{letterId}/reply/complaint")
+    @PostMapping("/letters/{letterId}/reply/complaint")
     public ApiResponse<?> complainKeywordReplyLetter(@PathVariable Long letterId,
                                                      @RequestBody ComplaintRequestDTO complaintRequest,
                                                      BindingResult bindingResult) {

--- a/src/main/java/postman/bottler/complaint/domain/Complaint.java
+++ b/src/main/java/postman/bottler/complaint/domain/Complaint.java
@@ -1,5 +1,6 @@
 package postman.bottler.complaint.domain;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,17 +15,21 @@ public class Complaint {
 
     private String description;
 
+    private LocalDateTime createdAt;
+
     protected Complaint(Long letterId, Long reporterId, String description) {
         this.letterId = letterId;
         this.reporterId = reporterId;
         this.description = description;
+        this.createdAt = LocalDateTime.now();
     }
 
-    protected Complaint(Long id, Long letterId, Long reporterId, String description) {
+    protected Complaint(Long id, Long letterId, Long reporterId, String description, LocalDateTime createdAt) {
         this.id = id;
         this.letterId = letterId;
         this.reporterId = reporterId;
         this.description = description;
+        this.createdAt = createdAt;
     }
 
     public Boolean isReporter(Long reporterId) {

--- a/src/main/java/postman/bottler/complaint/domain/KeywordComplaint.java
+++ b/src/main/java/postman/bottler/complaint/domain/KeywordComplaint.java
@@ -1,5 +1,7 @@
 package postman.bottler.complaint.domain;
 
+import java.time.LocalDateTime;
+
 public class KeywordComplaint extends Complaint {
     private KeywordComplaint(Long letterId, Long reporterId, String description) {
         super(letterId, reporterId, description);
@@ -9,11 +11,12 @@ public class KeywordComplaint extends Complaint {
         return new KeywordComplaint(letterId, reporterId, description);
     }
 
-    private KeywordComplaint(Long id, Long letterId, Long reporterId, String description) {
-        super(id, letterId, reporterId, description);
+    private KeywordComplaint(Long id, Long letterId, Long reporterId, String description, LocalDateTime createdAt) {
+        super(id, letterId, reporterId, description, createdAt);
     }
 
-    public static KeywordComplaint of(Long id, Long letterId, Long reporterId, String description) {
-        return new KeywordComplaint(id, letterId, reporterId, description);
+    public static KeywordComplaint of(Long id, Long letterId, Long reporterId, String description,
+                                      LocalDateTime createdAt) {
+        return new KeywordComplaint(id, letterId, reporterId, description, createdAt);
     }
 }

--- a/src/main/java/postman/bottler/complaint/domain/KeywordReplyComplaint.java
+++ b/src/main/java/postman/bottler/complaint/domain/KeywordReplyComplaint.java
@@ -1,5 +1,7 @@
 package postman.bottler.complaint.domain;
 
+import java.time.LocalDateTime;
+
 public class KeywordReplyComplaint extends Complaint {
     private KeywordReplyComplaint(Long letterId, Long reporterId, String description) {
         super(letterId, reporterId, description);
@@ -9,11 +11,13 @@ public class KeywordReplyComplaint extends Complaint {
         return new KeywordReplyComplaint(letterId, reporterId, description);
     }
 
-    private KeywordReplyComplaint(Long id, Long letterId, Long reporterId, String description) {
-        super(id, letterId, reporterId, description);
+    private KeywordReplyComplaint(Long id, Long letterId, Long reporterId, String description,
+                                  LocalDateTime createdAt) {
+        super(id, letterId, reporterId, description, createdAt);
     }
 
-    public static KeywordReplyComplaint of(Long id, Long letterId, Long reporterId, String description) {
-        return new KeywordReplyComplaint(id, letterId, reporterId, description);
+    public static KeywordReplyComplaint of(Long id, Long letterId, Long reporterId, String description,
+                                           LocalDateTime createdAt) {
+        return new KeywordReplyComplaint(id, letterId, reporterId, description, createdAt);
     }
 }

--- a/src/main/java/postman/bottler/complaint/domain/MapComplaint.java
+++ b/src/main/java/postman/bottler/complaint/domain/MapComplaint.java
@@ -1,5 +1,7 @@
 package postman.bottler.complaint.domain;
 
+import java.time.LocalDateTime;
+
 public class MapComplaint extends Complaint {
     private MapComplaint(Long letterId, Long reporterId, String description) {
         super(letterId, reporterId, description);
@@ -9,11 +11,12 @@ public class MapComplaint extends Complaint {
         return new MapComplaint(letterId, reporterId, description);
     }
 
-    private MapComplaint(Long id, Long letterId, Long reporterId, String description) {
-        super(id, letterId, reporterId, description);
+    private MapComplaint(Long id, Long letterId, Long reporterId, String description, LocalDateTime createdAt) {
+        super(id, letterId, reporterId, description, createdAt);
     }
 
-    public static MapComplaint of(Long id, Long letterId, Long reporterId, String description) {
-        return new MapComplaint(id, letterId, reporterId, description);
+    public static MapComplaint of(Long id, Long letterId, Long reporterId, String description,
+                                  LocalDateTime createdAt) {
+        return new MapComplaint(id, letterId, reporterId, description, createdAt);
     }
 }

--- a/src/main/java/postman/bottler/complaint/domain/MapReplyComplaint.java
+++ b/src/main/java/postman/bottler/complaint/domain/MapReplyComplaint.java
@@ -1,5 +1,7 @@
 package postman.bottler.complaint.domain;
 
+import java.time.LocalDateTime;
+
 public class MapReplyComplaint extends Complaint {
     private MapReplyComplaint(Long letterId, Long reporterId, String description) {
         super(letterId, reporterId, description);
@@ -9,11 +11,12 @@ public class MapReplyComplaint extends Complaint {
         return new MapReplyComplaint(letterId, reporterId, description);
     }
 
-    private MapReplyComplaint(Long id, Long letterId, Long reporterId, String description) {
-        super(id, letterId, reporterId, description);
+    private MapReplyComplaint(Long id, Long letterId, Long reporterId, String description, LocalDateTime createdAt) {
+        super(id, letterId, reporterId, description, createdAt);
     }
 
-    public static MapReplyComplaint of(Long id, Long letterId, Long reporterId, String description) {
-        return new MapReplyComplaint(id, letterId, reporterId, description);
+    public static MapReplyComplaint of(Long id, Long letterId, Long reporterId, String description,
+                                       LocalDateTime createdAt) {
+        return new MapReplyComplaint(id, letterId, reporterId, description, createdAt);
     }
 }

--- a/src/main/java/postman/bottler/complaint/infra/keyword/KeywordComplaintEntity.java
+++ b/src/main/java/postman/bottler/complaint/infra/keyword/KeywordComplaintEntity.java
@@ -11,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 import postman.bottler.complaint.domain.KeywordComplaint;
 
 @Entity
@@ -31,7 +30,6 @@ public class KeywordComplaintEntity {
 
     private String description;
 
-    @CreationTimestamp
     private LocalDateTime createdAt;
 
     public static KeywordComplaintEntity from(KeywordComplaint complaint) {
@@ -40,10 +38,11 @@ public class KeywordComplaintEntity {
                 .letterId(complaint.getLetterId())
                 .reporterId(complaint.getReporterId())
                 .description(complaint.getDescription())
+                .createdAt(complaint.getCreatedAt())
                 .build();
     }
 
     public KeywordComplaint toDomain() {
-        return KeywordComplaint.of(id, letterId, reporterId, description);
+        return KeywordComplaint.of(id, letterId, reporterId, description, createdAt);
     }
 }

--- a/src/main/java/postman/bottler/complaint/infra/keyword/KeywordReplyComplaintEntity.java
+++ b/src/main/java/postman/bottler/complaint/infra/keyword/KeywordReplyComplaintEntity.java
@@ -11,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 import postman.bottler.complaint.domain.KeywordReplyComplaint;
 
 @Entity
@@ -31,7 +30,6 @@ public class KeywordReplyComplaintEntity {
 
     private String description;
 
-    @CreationTimestamp
     private LocalDateTime createdAt;
 
     public static KeywordReplyComplaintEntity from(KeywordReplyComplaint complaint) {
@@ -40,10 +38,11 @@ public class KeywordReplyComplaintEntity {
                 .letterId(complaint.getLetterId())
                 .reporterId(complaint.getReporterId())
                 .description(complaint.getDescription())
+                .createdAt(complaint.getCreatedAt())
                 .build();
     }
 
     public KeywordReplyComplaint toDomain() {
-        return KeywordReplyComplaint.of(id, letterId, reporterId, description);
+        return KeywordReplyComplaint.of(id, letterId, reporterId, description, createdAt);
     }
 }

--- a/src/main/java/postman/bottler/complaint/infra/map/MapComplaintEntity.java
+++ b/src/main/java/postman/bottler/complaint/infra/map/MapComplaintEntity.java
@@ -11,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 import postman.bottler.complaint.domain.MapComplaint;
 
 @Entity
@@ -31,7 +30,6 @@ public class MapComplaintEntity {
 
     private String description;
 
-    @CreationTimestamp
     private LocalDateTime createdAt;
 
     public static MapComplaintEntity from(MapComplaint complaint) {
@@ -40,10 +38,11 @@ public class MapComplaintEntity {
                 .letterId(complaint.getLetterId())
                 .reporterId(complaint.getReporterId())
                 .description(complaint.getDescription())
+                .createdAt(complaint.getCreatedAt())
                 .build();
     }
 
     public MapComplaint toDomain() {
-        return MapComplaint.of(id, letterId, reporterId, description);
+        return MapComplaint.of(id, letterId, reporterId, description, createdAt);
     }
 }

--- a/src/main/java/postman/bottler/complaint/infra/map/MapReplyComplaintEntity.java
+++ b/src/main/java/postman/bottler/complaint/infra/map/MapReplyComplaintEntity.java
@@ -11,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 import postman.bottler.complaint.domain.MapReplyComplaint;
 
 @Entity
@@ -31,7 +30,6 @@ public class MapReplyComplaintEntity {
 
     private String description;
 
-    @CreationTimestamp
     private LocalDateTime createdAt;
 
     public static MapReplyComplaintEntity from(MapReplyComplaint complaint) {
@@ -40,10 +38,11 @@ public class MapReplyComplaintEntity {
                 .letterId(complaint.getLetterId())
                 .reporterId(complaint.getReporterId())
                 .description(complaint.getDescription())
+                .createdAt(complaint.getCreatedAt())
                 .build();
     }
 
     public MapReplyComplaint toDomain() {
-        return MapReplyComplaint.of(id, letterId, reporterId, description);
+        return MapReplyComplaint.of(id, letterId, reporterId, description, createdAt);
     }
 }

--- a/src/test/java/postman/bottler/complaint/service/ComplaintServiceTest.java
+++ b/src/test/java/postman/bottler/complaint/service/ComplaintServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +41,8 @@ public class ComplaintServiceTest {
     public void complainKeywordLetter() {
         // GIVEN
         when(keywordComplaintRepository.findByLetterId(1L)).thenReturn(Complaints.from(new ArrayList<>()));
-        when(keywordComplaintRepository.save(any())).thenReturn(KeywordComplaint.of(1L, 1L, 1L, "욕설사용"));
+        when(keywordComplaintRepository.save(any())).thenReturn(
+                KeywordComplaint.of(1L, 1L, 1L, "욕설사용", LocalDateTime.now()));
 
         // WHEN
         ComplaintResponseDTO response = complaintService.complainKeywordLetter(1L, 1L, "욕설 사용");
@@ -53,7 +55,7 @@ public class ComplaintServiceTest {
     @DisplayName("같은 키워드 편지를 2회 이상 신고 시도할 경우, DuplicateComplainException을 발생시킨다.")
     public void duplicateKeywordComplain() {
         // GIVEN
-        KeywordComplaint complaint = KeywordComplaint.of(1L, 1L, 1L, "욕설사용");
+        KeywordComplaint complaint = KeywordComplaint.of(1L, 1L, 1L, "욕설사용", LocalDateTime.now());
         when(keywordComplaintRepository.findByLetterId(1L)).thenReturn(Complaints.from(new ArrayList<>()))
                 .thenReturn(Complaints.from(List.of(complaint)));
         when(keywordComplaintRepository.save(any())).thenReturn(complaint);
@@ -69,7 +71,7 @@ public class ComplaintServiceTest {
     public void complainMapLetter() {
         // GIVEN
         when(mapComplaintRepository.findByLetterId(1L)).thenReturn(Complaints.from(new ArrayList<>()));
-        when(mapComplaintRepository.save(any())).thenReturn(MapComplaint.of(1L, 1L, 1L, "욕설사용"));
+        when(mapComplaintRepository.save(any())).thenReturn(MapComplaint.of(1L, 1L, 1L, "욕설사용", LocalDateTime.now()));
 
         // WHEN
         ComplaintResponseDTO response = complaintService.complainMapLetter(1L, 1L, "욕설 사용");
@@ -82,7 +84,7 @@ public class ComplaintServiceTest {
     @DisplayName("같은 지도 편지를 2회 이상 신고 시도할 경우, DuplicateComplainException을 발생시킨다.")
     public void duplicateMapComplain() {
         // GIVEN
-        MapComplaint complaint = MapComplaint.of(1L, 1L, 1L, "욕설사용");
+        MapComplaint complaint = MapComplaint.of(1L, 1L, 1L, "욕설사용", LocalDateTime.now());
         when(mapComplaintRepository.findByLetterId(1L)).thenReturn(Complaints.from(new ArrayList<>()))
                 .thenReturn(Complaints.from(List.of(complaint)));
         when(mapComplaintRepository.save(any())).thenReturn(complaint);
@@ -98,7 +100,8 @@ public class ComplaintServiceTest {
     public void complainKeywordReplyLetter() {
         // GIVEN
         when(keywordReplyComplaintRepository.findByLetterId(1L)).thenReturn(Complaints.from(new ArrayList<>()));
-        when(keywordReplyComplaintRepository.save(any())).thenReturn(KeywordReplyComplaint.of(1L, 1L, 1L, "욕설사용"));
+        when(keywordReplyComplaintRepository.save(any())).thenReturn(
+                KeywordReplyComplaint.of(1L, 1L, 1L, "욕설사용", LocalDateTime.now()));
 
         // WHEN
         ComplaintResponseDTO response = complaintService.complainKeywordReplyLetter(1L, 1L, "욕설 사용");
@@ -111,7 +114,7 @@ public class ComplaintServiceTest {
     @DisplayName("같은 답장 편지를 2회 이상 신고 시도할 경우, DuplicateComplainException을 발생시킨다.")
     public void duplicateKeywordReplyComplain() {
         // GIVEN
-        KeywordReplyComplaint complaint = KeywordReplyComplaint.of(1L, 1L, 1L, "욕설사용");
+        KeywordReplyComplaint complaint = KeywordReplyComplaint.of(1L, 1L, 1L, "욕설사용", LocalDateTime.now());
         when(keywordReplyComplaintRepository.findByLetterId(1L)).thenReturn(Complaints.from(new ArrayList<>()))
                 .thenReturn(Complaints.from(List.of(complaint)));
         when(keywordReplyComplaintRepository.save(any())).thenReturn(complaint);
@@ -127,7 +130,8 @@ public class ComplaintServiceTest {
     public void complainMapReplyLetter() {
         // GIVEN
         when(mapReplyComplaintRepository.findByLetterId(1L)).thenReturn(Complaints.from(new ArrayList<>()));
-        when(mapReplyComplaintRepository.save(any())).thenReturn(MapReplyComplaint.of(1L, 1L, 1L, "욕설사용"));
+        when(mapReplyComplaintRepository.save(any())).thenReturn(
+                MapReplyComplaint.of(1L, 1L, 1L, "욕설사용", LocalDateTime.now()));
 
         // WHEN
         ComplaintResponseDTO response = complaintService.complainMapReplyLetter(1L, 1L, "욕설 사용");
@@ -140,7 +144,7 @@ public class ComplaintServiceTest {
     @DisplayName("같은 답장 편지를 2회 이상 신고 시도할 경우, DuplicateComplainException을 발생시킨다.")
     public void duplicateMapReplyComplain() {
         // GIVEN
-        MapReplyComplaint complaint = MapReplyComplaint.of(1L, 1L, 1L, "욕설사용");
+        MapReplyComplaint complaint = MapReplyComplaint.of(1L, 1L, 1L, "욕설사용", LocalDateTime.now());
         when(mapReplyComplaintRepository.findByLetterId(1L)).thenReturn(Complaints.from(new ArrayList<>()))
                 .thenReturn(Complaints.from(List.of(complaint)));
         when(mapReplyComplaintRepository.save(any())).thenReturn(complaint);


### PR DESCRIPTION
## 📢 기능 설명 
createdAt을 기존에 인프라 계층에서 생성하고, 도메인 계층에서는 `createdAt`을 관리하지 않았습니다. 따라서 기존에 저장된 신고 도메인을 불러온 후 다시 JPA Entity로 변환할 시, `createdAt`이 null이 되는 문제가 발생했습니다.

따라서 신고 생성 시, `createdAt` 지정하는 로직을 인프라 계층의 JPA `@CreationStamp`를 사용하지 않고 서비스 계층에서 지정하도록 수정하였습니다.

## 연결된 issue
close #66 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
