### PR TITLE
[Refactor/#68] 알림 답장 키워드/지도 구분

### DIFF
--- a/src/main/java/postman/bottler/complaint/service/ComplaintService.java
+++ b/src/main/java/postman/bottler/complaint/service/ComplaintService.java
@@ -9,6 +9,7 @@ import postman.bottler.complaint.domain.KeywordReplyComplaint;
 import postman.bottler.complaint.domain.MapComplaint;
 import postman.bottler.complaint.domain.MapReplyComplaint;
 import postman.bottler.complaint.dto.response.ComplaintResponseDTO;
+import postman.bottler.notification.service.NotificationService;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +18,8 @@ public class ComplaintService {
     private final MapComplaintRepository mapComplaintRepository;
     private final KeywordReplyComplaintRepository keywordReplyComplaintRepository;
     private final MapReplyComplaintRepository mapReplyComplaintRepository;
+
+    private final NotificationService notificationService;
 
     @Transactional
     public ComplaintResponseDTO complainKeywordLetter(Long letterId, Long reporterId,

--- a/src/main/java/postman/bottler/notification/controller/NotificationController.java
+++ b/src/main/java/postman/bottler/notification/controller/NotificationController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import postman.bottler.global.response.ApiResponse;
+import postman.bottler.notification.domain.NotificationType;
 import postman.bottler.notification.dto.request.NotificationRequestDTO;
 import postman.bottler.notification.dto.request.SubscriptionRequestDTO;
 import postman.bottler.notification.dto.request.UnsubscriptionRequestDTO;
@@ -34,13 +35,13 @@ public class NotificationController {
 
     @Operation(summary = "알림 생성", description = "알림 유형, 알림 대상은 필수, 편지 관련 알림은 편지 ID를 등록합니다.")
     @PostMapping
-    public ApiResponse<NotificationResponseDTO> create(@Valid @RequestBody NotificationRequestDTO notificationRequestDTO,
-                                 BindingResult bindingResult) {
+    public ApiResponse<NotificationResponseDTO> create(
+            @Valid @RequestBody NotificationRequestDTO notificationRequestDTO, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new InvalidNotificationRequestException(bindingResult.getAllErrors().get(0).getDefaultMessage());
         }
         NotificationResponseDTO response = notificationService.sendNotification(
-                notificationRequestDTO.notificationType(),
+                NotificationType.from(notificationRequestDTO.notificationType()),
                 notificationRequestDTO.receiver(),
                 notificationRequestDTO.letterId());
         return ApiResponse.onCreateSuccess(response);
@@ -48,7 +49,8 @@ public class NotificationController {
 
     @Operation(summary = "알림 조회", description = "사용자의 알림을 조회합니다.")
     @GetMapping
-    public ApiResponse<List<NotificationResponseDTO>> getNotifications(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ApiResponse<List<NotificationResponseDTO>> getNotifications(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         List<NotificationResponseDTO> userNotifications = notificationService.getUserNotifications(
                 customUserDetails.getUserId());
         return ApiResponse.onSuccess(userNotifications);
@@ -57,7 +59,7 @@ public class NotificationController {
     @Operation(summary = "알림 허용", description = "사용자의 기기 토큰을 등록합니다.")
     @PostMapping("/subscribe")
     public ApiResponse<SubscriptionResponseDTO> subscribe(@RequestBody SubscriptionRequestDTO subscriptionRequest,
-                                    @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+                                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         SubscriptionResponseDTO response = subscriptionService.subscribe(
                 customUserDetails.getUserId(),
                 subscriptionRequest.token());

--- a/src/main/java/postman/bottler/notification/domain/Notification.java
+++ b/src/main/java/postman/bottler/notification/domain/Notification.java
@@ -32,12 +32,11 @@ public class Notification {
         this.isRead = isRead;
     }
 
-    public static Notification create(String type, Long receiver, Long letterId) {
-        NotificationType notificationType = NotificationType.from(type);
-        if (notificationType.isLetterNotification()) {
-            return new LetterNotification(notificationType, receiver, letterId, false);
+    public static Notification create(NotificationType type, Long receiver, Long letterId) {
+        if (type.isLetterNotification()) {
+            return new LetterNotification(type, receiver, letterId, false);
         }
-        return new Notification(notificationType, receiver, false);
+        return new Notification(type, receiver, false);
     }
 
     public static Notification of(UUID id, NotificationType type, Long receiver,

--- a/src/main/java/postman/bottler/notification/domain/Notification.java
+++ b/src/main/java/postman/bottler/notification/domain/Notification.java
@@ -48,7 +48,12 @@ public class Notification {
         return new Notification(id, type, receiver, createdAt, isRead);
     }
 
-    public void read() {
-        this.isRead = true;
+    public Boolean isLetterNotification() {
+        return type.isLetterNotification();
+    }
+
+    public Notification read() {
+        return Notification.of(id, type, receiver,
+                isLetterNotification() ? ((LetterNotification) this).getLetterId() : null, createdAt, true);
     }
 }

--- a/src/main/java/postman/bottler/notification/domain/NotificationType.java
+++ b/src/main/java/postman/bottler/notification/domain/NotificationType.java
@@ -7,7 +7,8 @@ import postman.bottler.notification.exception.NoTypeException;
 public enum NotificationType {
     NEW_LETTER("새 편지 도착", "새로운 키워드 편지가 도착했어요."),
     TARGET_LETTER("새 편지 도착", "나에게 작성된 지도 편지가 있어요."),
-    REPLY_LETTER("새 편지 도착", "내가 작성한 편지의 답장이 도착했어요."),
+    KEYWORD_REPLY("새 편지 도착", "내가 작성한 편지의 답장이 도착했어요."),
+    MAP_REPLY("새 편지 도착", "내가 작성한 편지의 답장이 도착했어요."),
     WARNING("경고 안내", "신고가 누적된 편지가 존재합니다."),
     BAN("정지 안내", "경고 누적으로 당분간 편지 작성이 제한됩니다.");
 
@@ -20,9 +21,8 @@ public enum NotificationType {
     }
 
     public Boolean isLetterNotification() {
-        return this == NotificationType.NEW_LETTER ||
-                this == NotificationType.TARGET_LETTER ||
-                this == NotificationType.REPLY_LETTER;
+        return this == NotificationType.NEW_LETTER || this == NotificationType.TARGET_LETTER ||
+                this == NotificationType.KEYWORD_REPLY || this == NotificationType.MAP_REPLY;
     }
 
     public static NotificationType from(String type) {

--- a/src/main/java/postman/bottler/notification/domain/Notifications.java
+++ b/src/main/java/postman/bottler/notification/domain/Notifications.java
@@ -1,5 +1,6 @@
 package postman.bottler.notification.domain;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import lombok.Builder;
@@ -21,12 +22,14 @@ public class Notifications {
         notifications.sort(Comparator.comparing(Notification::getCreatedAt).reversed());
     }
 
-    public void markAsRead() {
+    public Notifications markAsRead() {
+        List<Notification> changed = new ArrayList<>();
         for (Notification notification : notifications) {
             if (!notification.getIsRead()) {
-                notification.read();
+                changed.add(notification.read());
             }
         }
+        return new Notifications(changed);
     }
 
     public List<NotificationResponseDTO> createDTO() {

--- a/src/main/java/postman/bottler/notification/infra/NotificationHashKey.java
+++ b/src/main/java/postman/bottler/notification/infra/NotificationHashKey.java
@@ -1,0 +1,20 @@
+package postman.bottler.notification.infra;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationHashKey {
+    NOTIFICATION_KEY("notification"),
+    ID("id"),
+    TYPE("type"),
+    RECEIVER("receiver"),
+    CREATED_AT("created_at"),
+    LETTER_ID("letter_id"),
+    IS_READ("is_read");
+
+    private final String key;
+
+    NotificationHashKey(String key) {
+        this.key = key;
+    }
+}

--- a/src/main/java/postman/bottler/notification/infra/RedisNotification.java
+++ b/src/main/java/postman/bottler/notification/infra/RedisNotification.java
@@ -8,7 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisTemplate;
 import postman.bottler.notification.domain.LetterNotification;
 import postman.bottler.notification.domain.Notification;
@@ -19,7 +18,6 @@ import postman.bottler.notification.domain.NotificationType;
 @Builder
 @Getter
 public class RedisNotification {
-    @Id
     private UUID id;
 
     private Long receiver;
@@ -37,8 +35,8 @@ public class RedisNotification {
                 .id(notification.getId())
                 .receiver(notification.getReceiver())
                 .type(notification.getType())
-                .letterId(notification instanceof LetterNotification ? ((LetterNotification) notification).getLetterId()
-                        : null)
+                .letterId(notification.isLetterNotification() ?
+                        ((LetterNotification) notification).getLetterId() : null)
                 .createdAt(notification.getCreatedAt())
                 .isRead(notification.getIsRead())
                 .build();
@@ -50,23 +48,23 @@ public class RedisNotification {
 
     public Map<String, Object> toMap() {
         HashMap<String, Object> map = new HashMap<>();
-        map.put("id", id);
-        map.put("receiver", receiver);
-        map.put("type", type);
-        map.put("letterId", letterId);
-        map.put("createdAt", createdAt);
-        map.put("isRead", isRead);
+        map.put(NotificationHashKey.ID.getKey(), id);
+        map.put(NotificationHashKey.RECEIVER.getKey(), receiver);
+        map.put(NotificationHashKey.TYPE.getKey(), type);
+        map.put(NotificationHashKey.LETTER_ID.getKey(), letterId);
+        map.put(NotificationHashKey.CREATED_AT.getKey(), createdAt);
+        map.put(NotificationHashKey.IS_READ.getKey(), isRead);
         return map;
     }
 
     public static RedisNotification create(RedisTemplate<String, Object> redisTemplate, String key) {
         return RedisNotification.builder()
-                .id((UUID) redisTemplate.opsForHash().get(key, "id"))
-                .type((NotificationType) redisTemplate.opsForHash().get(key, "type"))
-                .receiver((Long) redisTemplate.opsForHash().get(key, "receiver"))
-                .createdAt((LocalDateTime) redisTemplate.opsForHash().get(key, "createdAt"))
-                .letterId((Long) redisTemplate.opsForHash().get(key, "letterId"))
-                .isRead((Boolean) redisTemplate.opsForHash().get(key, "isRead"))
+                .id((UUID) redisTemplate.opsForHash().get(key, NotificationHashKey.ID.getKey()))
+                .type((NotificationType) redisTemplate.opsForHash().get(key, NotificationHashKey.TYPE.getKey()))
+                .receiver((Long) redisTemplate.opsForHash().get(key, NotificationHashKey.RECEIVER.getKey()))
+                .createdAt((LocalDateTime) redisTemplate.opsForHash().get(key, NotificationHashKey.CREATED_AT.getKey()))
+                .letterId((Long) redisTemplate.opsForHash().get(key, NotificationHashKey.LETTER_ID.getKey()))
+                .isRead((Boolean) redisTemplate.opsForHash().get(key, NotificationHashKey.IS_READ.getKey()))
                 .build();
     }
 

--- a/src/main/java/postman/bottler/notification/infra/RedisNotification.java
+++ b/src/main/java/postman/bottler/notification/infra/RedisNotification.java
@@ -1,5 +1,12 @@
 package postman.bottler.notification.infra;
 
+import static postman.bottler.notification.infra.NotificationHashKey.CREATED_AT;
+import static postman.bottler.notification.infra.NotificationHashKey.ID;
+import static postman.bottler.notification.infra.NotificationHashKey.IS_READ;
+import static postman.bottler.notification.infra.NotificationHashKey.LETTER_ID;
+import static postman.bottler.notification.infra.NotificationHashKey.RECEIVER;
+import static postman.bottler.notification.infra.NotificationHashKey.TYPE;
+
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,23 +55,23 @@ public class RedisNotification {
 
     public Map<String, Object> toMap() {
         HashMap<String, Object> map = new HashMap<>();
-        map.put(NotificationHashKey.ID.getKey(), id);
-        map.put(NotificationHashKey.RECEIVER.getKey(), receiver);
-        map.put(NotificationHashKey.TYPE.getKey(), type);
-        map.put(NotificationHashKey.LETTER_ID.getKey(), letterId);
-        map.put(NotificationHashKey.CREATED_AT.getKey(), createdAt);
-        map.put(NotificationHashKey.IS_READ.getKey(), isRead);
+        map.put(ID.getKey(), id);
+        map.put(RECEIVER.getKey(), receiver);
+        map.put(TYPE.getKey(), type);
+        map.put(LETTER_ID.getKey(), letterId);
+        map.put(CREATED_AT.getKey(), createdAt);
+        map.put(IS_READ.getKey(), isRead);
         return map;
     }
 
     public static RedisNotification create(RedisTemplate<String, Object> redisTemplate, String key) {
         return RedisNotification.builder()
-                .id((UUID) redisTemplate.opsForHash().get(key, NotificationHashKey.ID.getKey()))
-                .type((NotificationType) redisTemplate.opsForHash().get(key, NotificationHashKey.TYPE.getKey()))
-                .receiver((Long) redisTemplate.opsForHash().get(key, NotificationHashKey.RECEIVER.getKey()))
-                .createdAt((LocalDateTime) redisTemplate.opsForHash().get(key, NotificationHashKey.CREATED_AT.getKey()))
-                .letterId((Long) redisTemplate.opsForHash().get(key, NotificationHashKey.LETTER_ID.getKey()))
-                .isRead((Boolean) redisTemplate.opsForHash().get(key, NotificationHashKey.IS_READ.getKey()))
+                .id((UUID) redisTemplate.opsForHash().get(key, ID.getKey()))
+                .type((NotificationType) redisTemplate.opsForHash().get(key, TYPE.getKey()))
+                .receiver((Long) redisTemplate.opsForHash().get(key, RECEIVER.getKey()))
+                .createdAt((LocalDateTime) redisTemplate.opsForHash().get(key, CREATED_AT.getKey()))
+                .letterId((Long) redisTemplate.opsForHash().get(key, LETTER_ID.getKey()))
+                .isRead((Boolean) redisTemplate.opsForHash().get(key, IS_READ.getKey()))
                 .build();
     }
 

--- a/src/main/java/postman/bottler/notification/infra/RedisNotificationRepositoryImpl.java
+++ b/src/main/java/postman/bottler/notification/infra/RedisNotificationRepositoryImpl.java
@@ -1,5 +1,7 @@
 package postman.bottler.notification.infra;
 
+import static postman.bottler.notification.infra.NotificationHashKey.NOTIFICATION_KEY;
+
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -22,7 +24,7 @@ public class RedisNotificationRepositoryImpl implements NotificationRepository {
     @Override
     public Notification save(Notification notification) {
         RedisNotification redisNotification = RedisNotification.from(notification);
-        String notificationKey = NotificationHashKey.NOTIFICATION_KEY.getKey() + redisNotification.createRedisKey();
+        String notificationKey = NOTIFICATION_KEY.getKey() + redisNotification.createRedisKey();
         redisTemplate.opsForHash().putAll(notificationKey, redisNotification.toMap());
         redisTemplate.expire(notificationKey, TTL, TimeUnit.DAYS);
         return redisNotification.toDomain();
@@ -30,7 +32,7 @@ public class RedisNotificationRepositoryImpl implements NotificationRepository {
 
     @Override
     public Notifications findByReceiver(Long userId) {
-        Set<String> keys = redisTemplate.keys(NotificationHashKey.NOTIFICATION_KEY.getKey() + ":" + userId + ":*");
+        Set<String> keys = redisTemplate.keys(NOTIFICATION_KEY.getKey() + ":" + userId + ":*");
         List<Notification> notifications = keys.stream()
                 .map(key -> RedisNotification.create(redisTemplate, key))
                 .map(RedisNotification::toDomain)
@@ -42,7 +44,7 @@ public class RedisNotificationRepositoryImpl implements NotificationRepository {
     public void updateNotifications(Notifications notifications) {
         notifications.getNotifications().forEach(notification -> {
             RedisNotification redisNotification = RedisNotification.from(notification);
-            String notificationKey = NotificationHashKey.NOTIFICATION_KEY.getKey() + redisNotification.createRedisKey();
+            String notificationKey = NOTIFICATION_KEY.getKey() + redisNotification.createRedisKey();
             redisTemplate.opsForHash().putAll(notificationKey, redisNotification.toMap());
         });
     }

--- a/src/main/java/postman/bottler/notification/infra/RedisNotificationRepositoryImpl.java
+++ b/src/main/java/postman/bottler/notification/infra/RedisNotificationRepositoryImpl.java
@@ -1,7 +1,6 @@
 package postman.bottler.notification.infra;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -18,13 +17,12 @@ import postman.bottler.notification.service.NotificationRepository;
 @Slf4j
 public class RedisNotificationRepositoryImpl implements NotificationRepository {
     private final RedisTemplate<String, Object> redisTemplate;
-    private static final String NOTIFICATION_KEY = "notification";
     private static final long TTL = 7;
 
     @Override
     public Notification save(Notification notification) {
         RedisNotification redisNotification = RedisNotification.from(notification);
-        String notificationKey = NOTIFICATION_KEY + redisNotification.createRedisKey();
+        String notificationKey = NotificationHashKey.NOTIFICATION_KEY.getKey() + redisNotification.createRedisKey();
         redisTemplate.opsForHash().putAll(notificationKey, redisNotification.toMap());
         redisTemplate.expire(notificationKey, TTL, TimeUnit.DAYS);
         return redisNotification.toDomain();
@@ -32,12 +30,8 @@ public class RedisNotificationRepositoryImpl implements NotificationRepository {
 
     @Override
     public Notifications findByReceiver(Long userId) {
-        Set<String> keys = redisTemplate.keys(NOTIFICATION_KEY + ":" + userId + ":*");
+        Set<String> keys = redisTemplate.keys(NotificationHashKey.NOTIFICATION_KEY.getKey() + ":" + userId + ":*");
         List<Notification> notifications = keys.stream()
-                .filter(key -> {
-                    Long receiver = (Long) redisTemplate.opsForHash().get(key, "receiver");
-                    return Objects.equals(receiver, userId);
-                })
                 .map(key -> RedisNotification.create(redisTemplate, key))
                 .map(RedisNotification::toDomain)
                 .collect(Collectors.toList());
@@ -48,7 +42,7 @@ public class RedisNotificationRepositoryImpl implements NotificationRepository {
     public void updateNotifications(Notifications notifications) {
         notifications.getNotifications().forEach(notification -> {
             RedisNotification redisNotification = RedisNotification.from(notification);
-            String notificationKey = NOTIFICATION_KEY + redisNotification.createRedisKey();
+            String notificationKey = NotificationHashKey.NOTIFICATION_KEY.getKey() + redisNotification.createRedisKey();
             redisTemplate.opsForHash().putAll(notificationKey, redisNotification.toMap());
         });
     }

--- a/src/main/java/postman/bottler/notification/service/NotificationService.java
+++ b/src/main/java/postman/bottler/notification/service/NotificationService.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import postman.bottler.notification.domain.Notification;
+import postman.bottler.notification.domain.NotificationType;
 import postman.bottler.notification.domain.Notifications;
 import postman.bottler.notification.domain.PushMessages;
 import postman.bottler.notification.domain.Subscriptions;
@@ -20,7 +21,7 @@ public class NotificationService {
     private final PushNotificationProvider pushNotificationProvider;
 
     @Transactional
-    public NotificationResponseDTO sendNotification(String type, Long userId, Long letterId) {
+    public NotificationResponseDTO sendNotification(NotificationType type, Long userId, Long letterId) {
         Notification notification = Notification.create(type, userId, letterId);
         Subscriptions subscriptions = subscriptionRepository.findByUserId(userId);
         NotificationResponseDTO result = NotificationResponseDTO.from(notificationRepository.save(notification));

--- a/src/main/java/postman/bottler/notification/service/NotificationService.java
+++ b/src/main/java/postman/bottler/notification/service/NotificationService.java
@@ -40,8 +40,8 @@ public class NotificationService {
         Notifications notifications = notificationRepository.findByReceiver(userId);
         notifications.orderByCreatedAt();
         List<NotificationResponseDTO> result = notifications.createDTO();
-        notifications.markAsRead();
-        notificationRepository.updateNotifications(notifications);
+        Notifications changed = notifications.markAsRead();
+        notificationRepository.updateNotifications(changed);
         return result;
     }
 }

--- a/src/test/java/postman/bottler/notification/domain/LetterNotificationTest.java
+++ b/src/test/java/postman/bottler/notification/domain/LetterNotificationTest.java
@@ -10,7 +10,7 @@ public class LetterNotificationTest {
     @Test
     @DisplayName("편지 알림 생성 시, 편지 ID가 존재하지 않는 경우, 예외를 발생시킨다.")
     public void createLetterNotificationWithNonLetter() {
-        Assertions.assertThatThrownBy(() -> Notification.create("NEW_LETTER", 1L, null))
+        Assertions.assertThatThrownBy(() -> Notification.create(NotificationType.NEW_LETTER, 1L, null))
                 .isInstanceOf(NoLetterIdException.class);
     }
 }

--- a/src/test/java/postman/bottler/notification/domain/NotificationTest.java
+++ b/src/test/java/postman/bottler/notification/domain/NotificationTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import postman.bottler.notification.dto.request.NotificationRequestDTO;
-import postman.bottler.notification.exception.InvalidNotificationRequestException;
 import postman.bottler.notification.exception.NoLetterIdException;
 import postman.bottler.notification.exception.NoTypeException;
 
@@ -91,10 +90,10 @@ public class NotificationTest {
         }
 
         @Test
-        @DisplayName("편지 답장 알림을 생성한다.")
-        public void replyLetterNotificationTest() {
+        @DisplayName("지도 편지 답장 알림을 생성한다.")
+        public void replyMapLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("REPLY_LETTER", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("MAP_REPLY", 1L, 1L);
 
             // WHEN
             Notification notification = Notification.create(
@@ -103,7 +102,26 @@ public class NotificationTest {
                     request.letterId());
 
             // THEN
-            assertThat(notification.getType()).isEqualTo(NotificationType.REPLY_LETTER);
+            assertThat(notification.getType()).isEqualTo(NotificationType.MAP_REPLY);
+            assertThat(notification.getReceiver()).isEqualTo(1L);
+            assertThat(notification).isInstanceOf(LetterNotification.class);
+            assertThat(((LetterNotification) notification).getLetterId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("키워드 편지 답장 알림을 생성한다.")
+        public void replyKeywordLetterNotificationTest() {
+            // GIVEN
+            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, 1L);
+
+            // WHEN
+            Notification notification = Notification.create(
+                    request.notificationType(),
+                    request.receiver(),
+                    request.letterId());
+
+            // THEN
+            assertThat(notification.getType()).isEqualTo(NotificationType.KEYWORD_REPLY);
             assertThat(notification.getReceiver()).isEqualTo(1L);
             assertThat(notification).isInstanceOf(LetterNotification.class);
             assertThat(((LetterNotification) notification).getLetterId()).isEqualTo(1L);
@@ -114,7 +132,7 @@ public class NotificationTest {
         @DisplayName("새 편지 생성 시, 편지 ID가 없으면 예외를 발생시킨다.")
         public void replyLetterNoLetterIdTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("REPLY_LETTER", 1L, null);
+            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, null);
 
             // WHEN
             assertThatThrownBy(
@@ -169,10 +187,10 @@ public class NotificationTest {
             Notification notification = Notification.create("NEW_LETTER", 1L, 1L);
 
             // WHEN
-            notification.read();
+            Notification read = notification.read();
 
             // THEN
-            assertThat(notification.getIsRead()).isTrue();
+            assertThat(read.getIsRead()).isTrue();
         }
     }
 }

--- a/src/test/java/postman/bottler/notification/domain/NotificationTest.java
+++ b/src/test/java/postman/bottler/notification/domain/NotificationTest.java
@@ -20,7 +20,8 @@ public class NotificationTest {
         NotificationRequestDTO wrong = new NotificationRequestDTO("WRONG", 1L, 1L);
 
         // WHEN - THEN
-        assertThatThrownBy(() -> Notification.create(wrong.notificationType(), wrong.receiver(), wrong.letterId()))
+        assertThatThrownBy(() -> Notification.create(NotificationType.from(wrong.notificationType()), wrong.receiver(),
+                wrong.letterId()))
                 .isInstanceOf(NoTypeException.class);
     }
 
@@ -35,9 +36,7 @@ public class NotificationTest {
 
             // WHEN
             Notification notification = Notification.create(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.NEW_LETTER);
@@ -54,7 +53,8 @@ public class NotificationTest {
 
             // WHEN
             assertThatThrownBy(
-                    () -> Notification.create(request.notificationType(), request.receiver(), request.letterId()))
+                    () -> Notification.create(NotificationType.from(request.notificationType()), request.receiver(),
+                            request.letterId()))
                     .isInstanceOf(NoLetterIdException.class);
         }
 
@@ -66,9 +66,7 @@ public class NotificationTest {
 
             // WHEN
             Notification notification = Notification.create(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.TARGET_LETTER);
@@ -85,7 +83,8 @@ public class NotificationTest {
 
             // WHEN
             assertThatThrownBy(
-                    () -> Notification.create(request.notificationType(), request.receiver(), request.letterId()))
+                    () -> Notification.create(NotificationType.from(request.notificationType()), request.receiver(),
+                            request.letterId()))
                     .isInstanceOf(NoLetterIdException.class);
         }
 
@@ -97,9 +96,7 @@ public class NotificationTest {
 
             // WHEN
             Notification notification = Notification.create(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.MAP_REPLY);
@@ -116,9 +113,7 @@ public class NotificationTest {
 
             // WHEN
             Notification notification = Notification.create(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.KEYWORD_REPLY);
@@ -136,7 +131,8 @@ public class NotificationTest {
 
             // WHEN
             assertThatThrownBy(
-                    () -> Notification.create(request.notificationType(), request.receiver(), request.letterId()))
+                    () -> Notification.create(NotificationType.from(request.notificationType()), request.receiver(),
+                            request.letterId()))
                     .isInstanceOf(NoLetterIdException.class);
         }
 
@@ -148,9 +144,7 @@ public class NotificationTest {
 
             // WHEN
             Notification notification = Notification.create(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.WARNING);
@@ -166,9 +160,7 @@ public class NotificationTest {
 
             // WHEN
             Notification notification = Notification.create(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.BAN);
@@ -184,7 +176,7 @@ public class NotificationTest {
         @DisplayName("알림을 읽는다면, 읽음 표시를 한다.")
         public void readNotification() {
             // GIVEN
-            Notification notification = Notification.create("NEW_LETTER", 1L, 1L);
+            Notification notification = Notification.create(NotificationType.NEW_LETTER, 1L, 1L);
 
             // WHEN
             Notification read = notification.read();

--- a/src/test/java/postman/bottler/notification/domain/NotificationTypeTest.java
+++ b/src/test/java/postman/bottler/notification/domain/NotificationTypeTest.java
@@ -15,14 +15,16 @@ public class NotificationTypeTest {
         // GIVEN
         NotificationType newLetter = NotificationType.NEW_LETTER;
         NotificationType targetLetter = NotificationType.TARGET_LETTER;
-        NotificationType replyLetter = NotificationType.REPLY_LETTER;
+        NotificationType mapReply = NotificationType.MAP_REPLY;
+        NotificationType keywordReply = NotificationType.KEYWORD_REPLY;
         NotificationType warning = NotificationType.WARNING;
         NotificationType ban = NotificationType.BAN;
 
         // WHEN
         Boolean letter1 = newLetter.isLetterNotification();
         Boolean letter2 = targetLetter.isLetterNotification();
-        Boolean letter3 = replyLetter.isLetterNotification();
+        Boolean letter3 = mapReply.isLetterNotification();
+        Boolean letter4 = keywordReply.isLetterNotification();
         Boolean nonLetter1 = warning.isLetterNotification();
         Boolean nonLetter2 = ban.isLetterNotification();
 
@@ -40,21 +42,24 @@ public class NotificationTypeTest {
         // GIVEN
         String newLetter = "NEW_LETTER";
         String targetLetter = "TARGET_LETTER";
-        String replyLetter = "REPLY_LETTER";
+        String mapReply = "MAP_REPLY";
+        String keywordReply = "KEYWORD_REPLY";
         String warning = "WARNING";
         String ban = "BAN";
 
         // WHEN
         NotificationType newLetterType = NotificationType.from(newLetter);
         NotificationType targetLetterType = NotificationType.from(targetLetter);
-        NotificationType replyLetterType = NotificationType.from(replyLetter);
+        NotificationType mapReplyType = NotificationType.from(mapReply);
+        NotificationType keywordReplyType = NotificationType.from(keywordReply);
         NotificationType warningType = NotificationType.from(warning);
         NotificationType banType = NotificationType.from(ban);
 
         // THEN
         assertThat(newLetterType).isEqualTo(NotificationType.NEW_LETTER);
         assertThat(targetLetterType).isEqualTo(NotificationType.TARGET_LETTER);
-        assertThat(replyLetterType).isEqualTo(NotificationType.REPLY_LETTER);
+        assertThat(mapReplyType).isEqualTo(NotificationType.MAP_REPLY);
+        assertThat(keywordReplyType).isEqualTo(NotificationType.KEYWORD_REPLY);
         assertThat(warningType).isEqualTo(NotificationType.WARNING);
         assertThat(banType).isEqualTo(NotificationType.BAN);
     }

--- a/src/test/java/postman/bottler/notification/service/NotificationServiceTest.java
+++ b/src/test/java/postman/bottler/notification/service/NotificationServiceTest.java
@@ -85,10 +85,10 @@ public class NotificationServiceTest {
         }
 
         @Test
-        @DisplayName("답장 편지 알림을 보낸다.")
-        public void sendReplyLetterNotificationTest() {
+        @DisplayName("지도 답장 편지 알림을 보낸다.")
+        public void sendMapReplyLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("REPLY_LETTER", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("MAP_REPLY", 1L, 1L);
             Notification notification = Notification.create(request.notificationType(), request.receiver(),
                     request.letterId());
             when(notificationRepository.save(any())).thenReturn(notification);
@@ -103,7 +103,30 @@ public class NotificationServiceTest {
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
-            assertThat(response.type()).isEqualTo(NotificationType.REPLY_LETTER);
+            assertThat(response.type()).isEqualTo(NotificationType.MAP_REPLY);
+            assertThat(response.letterId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("키워드 답장 편지 알림을 보낸다.")
+        public void sendKeywordReplyLetterNotificationTest() {
+            // GIVEN
+            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, 1L);
+            Notification notification = Notification.create(request.notificationType(), request.receiver(),
+                    request.letterId());
+            when(notificationRepository.save(any())).thenReturn(notification);
+            when(subscriptionRepository.findByUserId(1L))
+                    .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
+
+            // WHEN
+            NotificationResponseDTO response = notificationService.sendNotification(
+                    request.notificationType(),
+                    request.receiver(),
+                    request.letterId());
+
+            // THEN
+            assertThat(response.receiver()).isEqualTo(1L);
+            assertThat(response.type()).isEqualTo(NotificationType.KEYWORD_REPLY);
             assertThat(response.letterId()).isEqualTo(1L);
         }
 
@@ -188,25 +211,23 @@ public class NotificationServiceTest {
             ArrayList<Notification> notifications = new ArrayList<>();
             notifications.add(Notification.create("NEW_LETTER", 1L, 1L));
             notifications.add(Notification.create("TARGET_LETTER", 1L, 1L));
-            notifications.add(Notification.create("REPLY_LETTER", 1L, 1L));
+            notifications.add(Notification.create("MAP_REPLY", 1L, 1L));
+            notifications.add(Notification.create("KEYWORD_REPLY", 1L, 1L));
             notifications.add(Notification.create("WARNING", 1L, null));
             notifications.add(Notification.create("BAN", 1L, null));
 
             Notifications notReadNotification = Notifications.from(notifications);
 
             when(notificationRepository.findByReceiver(any())).thenReturn(notReadNotification)
-                    .thenAnswer(invocation -> {
-                        notReadNotification.markAsRead();
-                        return notReadNotification;
-                    });
+                    .thenReturn(notReadNotification.markAsRead());
 
             // WHEN
             List<NotificationResponseDTO> notReadResponse = notificationService.getUserNotifications(1L);
             List<NotificationResponseDTO> readResponse = notificationService.getUserNotifications(1L);
 
             // THEN
-            assertThat(notReadResponse.stream().filter(r -> !r.isRead()).count()).isEqualTo(5L);
-            assertThat(readResponse.stream().filter(NotificationResponseDTO::isRead).count()).isEqualTo(5L);
+            assertThat(notReadResponse.stream().filter(r -> !r.isRead()).count()).isEqualTo(6L);
+            assertThat(readResponse.stream().filter(NotificationResponseDTO::isRead).count()).isEqualTo(6L);
         }
     }
 }

--- a/src/test/java/postman/bottler/notification/service/NotificationServiceTest.java
+++ b/src/test/java/postman/bottler/notification/service/NotificationServiceTest.java
@@ -43,15 +43,15 @@ public class NotificationServiceTest {
         public void sendNewLetterNotificationTest() {
             // GIVEN
             NotificationRequestDTO request = new NotificationRequestDTO("NEW_LETTER", 1L, 1L);
-            Notification notification = Notification.create(request.notificationType(), request.receiver(),
-                    request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    request.notificationType(),
+                    NotificationType.from(request.notificationType()),
                     request.receiver(),
                     request.letterId());
 
@@ -66,17 +66,15 @@ public class NotificationServiceTest {
         public void sendTargetLetterNotificationTest() {
             // GIVEN
             NotificationRequestDTO request = new NotificationRequestDTO("TARGET_LETTER", 1L, 1L);
-            Notification notification = Notification.create(request.notificationType(), request.receiver(),
-                    request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
@@ -89,17 +87,15 @@ public class NotificationServiceTest {
         public void sendMapReplyLetterNotificationTest() {
             // GIVEN
             NotificationRequestDTO request = new NotificationRequestDTO("MAP_REPLY", 1L, 1L);
-            Notification notification = Notification.create(request.notificationType(), request.receiver(),
-                    request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
@@ -112,17 +108,15 @@ public class NotificationServiceTest {
         public void sendKeywordReplyLetterNotificationTest() {
             // GIVEN
             NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, 1L);
-            Notification notification = Notification.create(request.notificationType(), request.receiver(),
-                    request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
@@ -135,17 +129,15 @@ public class NotificationServiceTest {
         public void sendWarningNotificationTest() {
             // GIVEN
             NotificationRequestDTO request = new NotificationRequestDTO("WARNING", 1L, 1L);
-            Notification notification = Notification.create(request.notificationType(), request.receiver(),
-                    request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
@@ -158,17 +150,15 @@ public class NotificationServiceTest {
         public void sendBanNotificationTest() {
             // GIVEN
             NotificationRequestDTO request = new NotificationRequestDTO("BAN", 1L, 1L);
-            Notification notification = Notification.create(request.notificationType(), request.receiver(),
-                    request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
@@ -181,17 +171,15 @@ public class NotificationServiceTest {
         public void notSendPushNotification() {
             // GIVEN
             NotificationRequestDTO request = new NotificationRequestDTO("BAN", 1L, 1L);
-            Notification notification = Notification.create(request.notificationType(), request.receiver(),
-                    request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of()));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    request.notificationType(),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
@@ -209,12 +197,12 @@ public class NotificationServiceTest {
         public void getNotifications() {
             // GIVEN
             ArrayList<Notification> notifications = new ArrayList<>();
-            notifications.add(Notification.create("NEW_LETTER", 1L, 1L));
-            notifications.add(Notification.create("TARGET_LETTER", 1L, 1L));
-            notifications.add(Notification.create("MAP_REPLY", 1L, 1L));
-            notifications.add(Notification.create("KEYWORD_REPLY", 1L, 1L));
-            notifications.add(Notification.create("WARNING", 1L, null));
-            notifications.add(Notification.create("BAN", 1L, null));
+            notifications.add(Notification.create(NotificationType.from("NEW_LETTER"), 1L, 1L));
+            notifications.add(Notification.create(NotificationType.from("TARGET_LETTER"), 1L, 1L));
+            notifications.add(Notification.create(NotificationType.from("MAP_REPLY"), 1L, 1L));
+            notifications.add(Notification.create(NotificationType.from("KEYWORD_REPLY"), 1L, 1L));
+            notifications.add(Notification.create(NotificationType.from("WARNING"), 1L, null));
+            notifications.add(Notification.create(NotificationType.from("BAN"), 1L, null));
 
             Notifications notReadNotification = Notifications.from(notifications);
 


### PR DESCRIPTION
## 📢 기능 설명 
**키워드 답장/지도 답장 테이블 구분**에 따라 답장 편지 알림도 `키워드 답장`과 `지도 답장`으로 나누었습니다.
- 기존
  - `REPLY_LETTER`
- 변경
  - `KEYWORD_REPLY`
  - `MAP_REPLY `

## 연결된 issue
close #68 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
