### PR TITLE
fix: #104 타겟 편지 작성시 타겟 유저 닉네임으로 받도록 수정

### DIFF
--- a/src/main/java/postman/bottler/mapletter/domain/MapLetter.java
+++ b/src/main/java/postman/bottler/mapletter/domain/MapLetter.java
@@ -57,7 +57,7 @@ public class MapLetter {
     }
 
     public static MapLetter createTargetMapLetter(CreateTargetMapLetterRequestDTO createTargetMapLetterRequestDTO,
-                                                  Long userId) {
+                                                  Long userId, Long targetUserId) {
         return MapLetter.builder()
                 .title(createTargetMapLetterRequestDTO.title())
                 .content(createTargetMapLetterRequestDTO.content())
@@ -68,7 +68,7 @@ public class MapLetter {
                 .label(createTargetMapLetterRequestDTO.label())
                 .type(MapLetterType.PRIVATE)
                 .createUserId(userId)
-                .targetUserId(createTargetMapLetterRequestDTO.target())
+                .targetUserId(targetUserId)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .isDeleted(false)

--- a/src/main/java/postman/bottler/mapletter/dto/request/CreateTargetMapLetterRequestDTO.java
+++ b/src/main/java/postman/bottler/mapletter/dto/request/CreateTargetMapLetterRequestDTO.java
@@ -14,6 +14,6 @@ public record CreateTargetMapLetterRequestDTO(
         String font,
         String paper,
         String label,
-        @NotNull(message = "타겟 유저는 생략할 수 없습니다.") Long target
+        @NotNull(message = "타겟 유저는 생략할 수 없습니다.") String target
 ) {
 }

--- a/src/main/java/postman/bottler/mapletter/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/service/MapLetterService.java
@@ -41,6 +41,7 @@ import postman.bottler.mapletter.exception.LetterAlreadyReplyException;
 import postman.bottler.mapletter.exception.MapLetterAlreadyArchivedException;
 import postman.bottler.mapletter.exception.PageRequestException;
 import postman.bottler.reply.dto.ReplyType;
+import postman.bottler.user.service.UserService;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +54,7 @@ public class MapLetterService {
 
     private static final double VIEW_DISTANCE = 15;
     private static final int REDIS_SAVED_REPLY = 6;
+    private final UserService userService;
 
     @Transactional
     public MapLetter createPublicMapLetter(CreatePublicMapLetterRequestDTO createPublicMapLetterRequestDTO,
@@ -64,7 +66,8 @@ public class MapLetterService {
     @Transactional
     public MapLetter createTargetMapLetter(CreateTargetMapLetterRequestDTO createTargetMapLetterRequestDTO,
                                            Long userId) {
-        MapLetter mapLetter = MapLetter.createTargetMapLetter(createTargetMapLetterRequestDTO, userId);
+        Long targetUserId=userService.getUserIdByNickname(createTargetMapLetterRequestDTO.target());
+        MapLetter mapLetter = MapLetter.createTargetMapLetter(createTargetMapLetterRequestDTO, userId, targetUserId);
         return mapLetterRepository.save(mapLetter);
     }
 


### PR DESCRIPTION
## 📢 기능 설명 
타겟 편지 작성시 타겟 유저 닉네임으로 받도록 수정
<br>

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #104 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
