### PR TITLE
[Refactor/#161] 키워드/타겟 편지 알림 조회 시 라벨 이미지 응답 추가

### DIFF
--- a/src/main/java/postman/bottler/letter/service/LetterService.java
+++ b/src/main/java/postman/bottler/letter/service/LetterService.java
@@ -14,6 +14,7 @@ import postman.bottler.letter.dto.request.LetterRequestDTO;
 import postman.bottler.letter.dto.response.LetterDetailResponseDTO;
 import postman.bottler.letter.dto.response.LetterRecommendHeadersResponseDTO;
 import postman.bottler.letter.exception.LetterNotFoundException;
+import postman.bottler.notification.dto.request.NotificationLabelRequestDTO;
 import postman.bottler.user.service.UserService;
 
 @Slf4j
@@ -75,5 +76,11 @@ public class LetterService {
 
     public boolean checkLetterExists(Long letterId) {
         return letterRepository.checkLetterExists(letterId);
+    }
+
+    public List<NotificationLabelRequestDTO> getLabels(List<Long> ids) {
+        return letterRepository.findAllByIds(ids).stream()
+                .map(find -> new NotificationLabelRequestDTO(find.getId(), find.getLabel()))
+                .toList();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
@@ -98,4 +98,11 @@ public class MapLetterRepositoryImpl implements MapLetterRepository {
     public List<MapLetterAndDistance> guestFindLettersByUserLocation(BigDecimal latitude, BigDecimal longitude) {
         return mapLetterJpaRepository.guestFindLettersByUserLocation(latitude, longitude);
     }
+
+    @Override
+    public List<MapLetter> findAllByIds(List<Long> ids) {
+        return mapLetterJpaRepository.findAllById(ids).stream()
+                .map(MapLetterEntity::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/service/MapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/service/MapLetterRepository.java
@@ -36,4 +36,6 @@ public interface MapLetterRepository {
     Page<FindReceivedMapLetterDTO> findActiveReceivedMapLettersByUserId(Long userId, PageRequest pageRequest);
 
     List<MapLetterAndDistance> guestFindLettersByUserLocation(BigDecimal latitude, BigDecimal longitude);
+
+    List<MapLetter> findAllByIds(List<Long> ids);
 }

--- a/src/main/java/postman/bottler/mapletter/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/service/MapLetterService.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -40,6 +39,7 @@ import postman.bottler.mapletter.dto.response.OneReplyLetterResponseDTO;
 import postman.bottler.mapletter.exception.LetterAlreadyReplyException;
 import postman.bottler.mapletter.exception.MapLetterAlreadyArchivedException;
 import postman.bottler.mapletter.exception.PageRequestException;
+import postman.bottler.notification.dto.request.NotificationLabelRequestDTO;
 import postman.bottler.reply.dto.ReplyType;
 import postman.bottler.user.service.UserService;
 
@@ -386,5 +386,13 @@ public class MapLetterService {
 
         String profileImg = userService.getProfileImageUrlById(mapLetter.getCreateUserId());
         return OneLetterResponseDTO.from(mapLetter, profileImg, false);
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationLabelRequestDTO> getLabels(List<Long> ids) {
+        List<MapLetter> finds = mapLetterRepository.findAllByIds(ids);
+        return finds.stream()
+                .map(find -> new NotificationLabelRequestDTO(find.getId(), find.getLabel()))
+                .toList();
     }
 }

--- a/src/main/java/postman/bottler/notification/controller/NotificationController.java
+++ b/src/main/java/postman/bottler/notification/controller/NotificationController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,7 +49,7 @@ public class NotificationController {
     }
 
     @Operation(summary = "알림 조회", description = "사용자의 알림을 조회합니다.")
-    @GetMapping
+    @PatchMapping
     public ApiResponse<List<NotificationResponseDTO>> getNotifications(
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         List<NotificationResponseDTO> userNotifications = notificationService.getUserNotifications(

--- a/src/main/java/postman/bottler/notification/domain/LetterNotification.java
+++ b/src/main/java/postman/bottler/notification/domain/LetterNotification.java
@@ -3,11 +3,15 @@ package postman.bottler.notification.domain;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.Setter;
 import postman.bottler.notification.exception.NoLetterIdException;
 
 @Getter
 public class LetterNotification extends Notification {
     private final long letterId;
+
+    @Setter
+    private String label;
 
     protected LetterNotification(NotificationType type, long receiver, Long letterId, Boolean isRead) {
         super(type, receiver, isRead);

--- a/src/main/java/postman/bottler/notification/domain/Notification.java
+++ b/src/main/java/postman/bottler/notification/domain/Notification.java
@@ -51,6 +51,14 @@ public class Notification {
         return type.isLetterNotification();
     }
 
+    public Boolean isKeywordLetterNotification() {
+        return type.equals(NotificationType.NEW_LETTER);
+    }
+
+    public Boolean isMapLetterNotification() {
+        return type.equals(NotificationType.TARGET_LETTER);
+    }
+
     public Notification read() {
         return Notification.of(id, type, receiver,
                 isLetterNotification() ? ((LetterNotification) this).getLetterId() : null, createdAt, true);

--- a/src/main/java/postman/bottler/notification/domain/Notifications.java
+++ b/src/main/java/postman/bottler/notification/domain/Notifications.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import postman.bottler.notification.dto.request.NotificationLabelRequestDTO;
 import postman.bottler.notification.dto.response.NotificationResponseDTO;
 
 @Builder
@@ -30,6 +31,55 @@ public class Notifications {
             }
         }
         return new Notifications(changed);
+    }
+
+    public List<Long> extractMapIds() {
+        List<Long> ids = new ArrayList<>();
+        for (Notification notification : notifications) {
+            if (notification.isMapLetterNotification()) {
+                ids.add(((LetterNotification) notification).getLetterId());
+            }
+        }
+        return ids;
+    }
+
+    public List<Long> extractKeywordIds() {
+        List<Long> ids = new ArrayList<>();
+        for (Notification notification : notifications) {
+            if (notification.isKeywordLetterNotification()) {
+                ids.add(((LetterNotification) notification).getLetterId());
+            }
+        }
+        return ids;
+    }
+
+    public void setMapLabels(List<NotificationLabelRequestDTO> mapLabels) {
+        for (Notification notification : notifications) {
+            if (!notification.isMapLetterNotification()) {
+                continue;
+            }
+            mapLabels.stream()
+                    .filter(label -> label.letterId() == ((LetterNotification) notification).getLetterId())
+                    .forEach(label -> ((LetterNotification) notification).setLabel(label.label()));
+        }
+    }
+
+    public void setKeywordLabels(List<NotificationLabelRequestDTO> keywordLabels) {
+        for (Notification notification : notifications) {
+            if (!notification.isKeywordLetterNotification()) {
+                continue;
+            }
+            keywordLabels.stream()
+                    .filter(label -> label.letterId() == ((LetterNotification) notification).getLetterId())
+                    .forEach(label -> ((LetterNotification) notification).setLabel(label.label()));
+        }
+    }
+
+    public List<Long> getLetterIds() {
+        return notifications.stream()
+                .filter(Notification::isLetterNotification)
+                .map(notification -> ((LetterNotification) notification).getLetterId())
+                .toList();
     }
 
     public List<NotificationResponseDTO> createDTO() {

--- a/src/main/java/postman/bottler/notification/dto/request/NotificationLabelRequestDTO.java
+++ b/src/main/java/postman/bottler/notification/dto/request/NotificationLabelRequestDTO.java
@@ -1,0 +1,7 @@
+package postman.bottler.notification.dto.request;
+
+public record NotificationLabelRequestDTO(
+        Long letterId,
+        String label
+) {
+}

--- a/src/main/java/postman/bottler/notification/dto/response/NotificationResponseDTO.java
+++ b/src/main/java/postman/bottler/notification/dto/response/NotificationResponseDTO.java
@@ -12,7 +12,8 @@ public record NotificationResponseDTO(
         Long receiver,
         LocalDateTime createdAt,
         Long letterId,
-        Boolean isRead
+        Boolean isRead,
+        String label
 ) {
     public static NotificationResponseDTO from(final Notification notification) {
         return new NotificationResponseDTO(
@@ -21,6 +22,7 @@ public record NotificationResponseDTO(
                 notification.getReceiver(),
                 notification.getCreatedAt(),
                 notification instanceof LetterNotification ? ((LetterNotification) notification).getLetterId() : null,
-                notification.getIsRead());
+                notification.getIsRead(),
+                notification instanceof LetterNotification ? ((LetterNotification) notification).getLabel() : null);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명 

키워드/타겟 편지 도착 알림의 경우, 해당 편지의 라벨 이미지를 추가적으로 알려줍니다.

### ⚠️  순환참조 오류로 인해 Notification에서 편지 Repository 참조 => 추후 수정 필수

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #161 161
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
