### PR TITLE
Feature/#165 : 알림 의존성 제거 및 타 도메인 알림 요청 추가

### DIFF
--- a/src/main/java/postman/bottler/complaint/service/ComplaintService.java
+++ b/src/main/java/postman/bottler/complaint/service/ComplaintService.java
@@ -37,7 +37,7 @@ public class ComplaintService {
         complaints.add(complaint);
         if (complaints.needsWarningNotification()) {
             Long writer = blockLetter(type, letterId);
-            notificationService.sendNotification(NotificationType.WARNING, writer, letterId);
+            notificationService.sendNotification(NotificationType.WARNING, writer, letterId, null);
             userService.updateWarningCount(writer);
         }
         return ComplaintResponseDTO.from(repository.save(complaint));

--- a/src/main/java/postman/bottler/letter/service/ReplyLetterService.java
+++ b/src/main/java/postman/bottler/letter/service/ReplyLetterService.java
@@ -1,5 +1,7 @@
 package postman.bottler.letter.service;
 
+import static postman.bottler.notification.domain.NotificationType.KEYWORD_REPLY;
+
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import postman.bottler.letter.dto.response.ReplyLetterResponseDTO;
 import postman.bottler.letter.exception.DuplicateReplyLetterException;
 import postman.bottler.letter.exception.LetterAuthorMismatchException;
 import postman.bottler.letter.exception.LetterNotFoundException;
+import postman.bottler.notification.service.NotificationService;
 import postman.bottler.reply.dto.ReplyType;
 
 @Service
@@ -28,6 +31,7 @@ public class ReplyLetterService {
     private final ReplyLetterRepository replyLetterRepository;
     private final LetterService letterService;
     private final LetterBoxService letterBoxService;
+    private final NotificationService notificationService;
     private final RedisTemplate<String, Object> redisTemplate;
 
     @Transactional
@@ -46,6 +50,8 @@ public class ReplyLetterService {
 
         saveLetterToBox(senderId, replyLetter, receiverId);
         saveRecentReply(letterId, letterReplyRequestDTO.label(), receiverId);
+        notificationService.sendNotification(KEYWORD_REPLY, receiverInfo.receiverId(), replyLetter.getLetterId(),
+                replyLetter.getLabel());
         return ReplyLetterResponseDTO.from(replyLetter);
     }
 

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
@@ -66,11 +66,12 @@ public class MapLetterRepositoryImpl implements MapLetterRepository {
     }
 
     @Override
-    public void findSourceMapLetterById(Long sourceMapLetterId) {
+    public MapLetter findSourceMapLetterById(Long sourceMapLetterId) {
         MapLetterEntity activeLetter = mapLetterJpaRepository.findActiveById(sourceMapLetterId);
         if (activeLetter == null) {
             throw new SourceMapLetterNotFountException("원본 편지를 찾을 수 없습니다. 편지가 존재하지 않거나 삭제되었습니다.");
         }
+        return MapLetterEntity.toDomain(activeLetter);
     }
 
     @Override

--- a/src/main/java/postman/bottler/mapletter/service/MapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/service/MapLetterRepository.java
@@ -25,7 +25,7 @@ public interface MapLetterRepository {
 
     List<MapLetterAndDistance> findLettersByUserLocation(BigDecimal latitude, BigDecimal longitude, Long userId);
 
-    void findSourceMapLetterById(Long sourceMapLetterId);
+    MapLetter findSourceMapLetterById(Long sourceMapLetterId);
 
     void letterBlock(Long letterId);
 

--- a/src/main/java/postman/bottler/mapletter/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/service/MapLetterService.java
@@ -1,5 +1,7 @@
 package postman.bottler.mapletter.service;
 
+import static postman.bottler.notification.domain.NotificationType.*;
+
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -39,7 +41,9 @@ import postman.bottler.mapletter.dto.response.OneReplyLetterResponseDTO;
 import postman.bottler.mapletter.exception.LetterAlreadyReplyException;
 import postman.bottler.mapletter.exception.MapLetterAlreadyArchivedException;
 import postman.bottler.mapletter.exception.PageRequestException;
+import postman.bottler.notification.domain.NotificationType;
 import postman.bottler.notification.dto.request.NotificationLabelRequestDTO;
+import postman.bottler.notification.service.NotificationService;
 import postman.bottler.reply.dto.ReplyType;
 import postman.bottler.user.service.UserService;
 
@@ -50,6 +54,7 @@ public class MapLetterService {
     private final ReplyMapLetterRepository replyMapLetterRepository;
     private final MapLetterArchiveRepository mapLetterArchiveRepository;
     private final UserService userService;
+    private final NotificationService notificationService;
     private final RedisTemplate<String, Object> redisTemplate;
 
     private static final double VIEW_DISTANCE = 15;
@@ -67,7 +72,9 @@ public class MapLetterService {
                                            Long userId) {
         Long targetUserId = userService.getUserIdByNickname(createTargetMapLetterRequestDTO.target());
         MapLetter mapLetter = MapLetter.createTargetMapLetter(createTargetMapLetterRequestDTO, userId, targetUserId);
-        return mapLetterRepository.save(mapLetter);
+        MapLetter save = mapLetterRepository.save(mapLetter);
+        notificationService.sendNotification(TARGET_LETTER, targetUserId, mapLetter.getId(), mapLetter.getLabel());
+        return save;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/postman/bottler/mapletter/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/service/MapLetterService.java
@@ -162,10 +162,12 @@ public class MapLetterService {
             throw new LetterAlreadyReplyException("해당 편지에 이미 답장을 했습니다.");
         }
 
-        mapLetterRepository.findSourceMapLetterById(createReplyMapLetterRequestDTO.sourceLetter());
+        MapLetter source = mapLetterRepository.findSourceMapLetterById(createReplyMapLetterRequestDTO.sourceLetter());
         ReplyMapLetter replyMapLetter = ReplyMapLetter.createReplyMapLetter(createReplyMapLetterRequestDTO, userId);
         ReplyMapLetter save = replyMapLetterRepository.save(replyMapLetter);
         saveRecentReply(save.getReplyLetterId(), save.getLabel(), save.getSourceLetterId());
+        notificationService.sendNotification(MAP_REPLY, source.getCreateUserId(), save.getReplyLetterId(),
+                save.getLabel());
         return save;
     }
 

--- a/src/main/java/postman/bottler/notification/controller/NotificationController.java
+++ b/src/main/java/postman/bottler/notification/controller/NotificationController.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,7 +33,8 @@ public class NotificationController {
     private final NotificationService notificationService;
     private final SubscriptionService subscriptionService;
 
-    @Operation(summary = "알림 생성", description = "알림 유형, 알림 대상은 필수, 편지 관련 알림은 편지 ID를 등록합니다.")
+    @Operation(summary = "알림 생성",
+            description = "알림 유형, 알림 대상은 필수, 편지 관련 알림은 편지 ID와 라벨 이미지를 등록합니다.")
     @PostMapping
     public ApiResponse<NotificationResponseDTO> create(
             @Valid @RequestBody NotificationRequestDTO notificationRequestDTO, BindingResult bindingResult) {
@@ -44,7 +44,7 @@ public class NotificationController {
         NotificationResponseDTO response = notificationService.sendNotification(
                 NotificationType.from(notificationRequestDTO.notificationType()),
                 notificationRequestDTO.receiver(),
-                notificationRequestDTO.letterId());
+                notificationRequestDTO.letterId(), notificationRequestDTO.label());
         return ApiResponse.onCreateSuccess(response);
     }
 

--- a/src/main/java/postman/bottler/notification/domain/LetterNotification.java
+++ b/src/main/java/postman/bottler/notification/domain/LetterNotification.java
@@ -13,17 +13,19 @@ public class LetterNotification extends Notification {
     @Setter
     private String label;
 
-    protected LetterNotification(NotificationType type, long receiver, Long letterId, Boolean isRead) {
+    protected LetterNotification(NotificationType type, long receiver, Long letterId, Boolean isRead, String label) {
         super(type, receiver, isRead);
         validateLetterId(letterId);
         this.letterId = letterId;
+        this.label = label;
     }
 
     protected LetterNotification(UUID id, NotificationType type, long receiver,
-                                 Long letterId, LocalDateTime createdAt, Boolean isRead) {
+                                 Long letterId, LocalDateTime createdAt, Boolean isRead, String label) {
         super(id, type, receiver, createdAt, isRead);
         validateLetterId(letterId);
         this.letterId = letterId;
+        this.label = label;
     }
 
     private void validateLetterId(Long letterId) {

--- a/src/main/java/postman/bottler/notification/domain/Notification.java
+++ b/src/main/java/postman/bottler/notification/domain/Notification.java
@@ -14,7 +14,7 @@ public class Notification {
 
     private final LocalDateTime createdAt;
 
-    private Boolean isRead;
+    private final Boolean isRead;
 
     protected Notification(NotificationType type, Long receiver, Boolean isRead) {
         this.id = UUID.randomUUID();
@@ -32,17 +32,17 @@ public class Notification {
         this.isRead = isRead;
     }
 
-    public static Notification create(NotificationType type, Long receiver, Long letterId) {
+    public static Notification create(NotificationType type, Long receiver, Long letterId, String label) {
         if (type.isLetterNotification()) {
-            return new LetterNotification(type, receiver, letterId, false);
+            return new LetterNotification(type, receiver, letterId, false, label);
         }
         return new Notification(type, receiver, false);
     }
 
     public static Notification of(UUID id, NotificationType type, Long receiver,
-                                  Long letterId, LocalDateTime createdAt, Boolean isRead) {
+                                  Long letterId, LocalDateTime createdAt, Boolean isRead, String label) {
         if (type.isLetterNotification()) {
-            return new LetterNotification(id, type, receiver, letterId, createdAt, isRead);
+            return new LetterNotification(id, type, receiver, letterId, createdAt, isRead, label);
         }
         return new Notification(id, type, receiver, createdAt, isRead);
     }
@@ -61,6 +61,7 @@ public class Notification {
 
     public Notification read() {
         return Notification.of(id, type, receiver,
-                isLetterNotification() ? ((LetterNotification) this).getLetterId() : null, createdAt, true);
+                isLetterNotification() ? ((LetterNotification) this).getLetterId() : null, createdAt, true,
+                isLetterNotification() ? ((LetterNotification) this).getLabel() : null);
     }
 }

--- a/src/main/java/postman/bottler/notification/domain/Notifications.java
+++ b/src/main/java/postman/bottler/notification/domain/Notifications.java
@@ -5,7 +5,6 @@ import java.util.Comparator;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-import postman.bottler.notification.dto.request.NotificationLabelRequestDTO;
 import postman.bottler.notification.dto.response.NotificationResponseDTO;
 
 @Builder
@@ -31,55 +30,6 @@ public class Notifications {
             }
         }
         return new Notifications(changed);
-    }
-
-    public List<Long> extractMapIds() {
-        List<Long> ids = new ArrayList<>();
-        for (Notification notification : notifications) {
-            if (notification.isMapLetterNotification()) {
-                ids.add(((LetterNotification) notification).getLetterId());
-            }
-        }
-        return ids;
-    }
-
-    public List<Long> extractKeywordIds() {
-        List<Long> ids = new ArrayList<>();
-        for (Notification notification : notifications) {
-            if (notification.isKeywordLetterNotification()) {
-                ids.add(((LetterNotification) notification).getLetterId());
-            }
-        }
-        return ids;
-    }
-
-    public void setMapLabels(List<NotificationLabelRequestDTO> mapLabels) {
-        for (Notification notification : notifications) {
-            if (!notification.isMapLetterNotification()) {
-                continue;
-            }
-            mapLabels.stream()
-                    .filter(label -> label.letterId() == ((LetterNotification) notification).getLetterId())
-                    .forEach(label -> ((LetterNotification) notification).setLabel(label.label()));
-        }
-    }
-
-    public void setKeywordLabels(List<NotificationLabelRequestDTO> keywordLabels) {
-        for (Notification notification : notifications) {
-            if (!notification.isKeywordLetterNotification()) {
-                continue;
-            }
-            keywordLabels.stream()
-                    .filter(label -> label.letterId() == ((LetterNotification) notification).getLetterId())
-                    .forEach(label -> ((LetterNotification) notification).setLabel(label.label()));
-        }
-    }
-
-    public List<Long> getLetterIds() {
-        return notifications.stream()
-                .filter(Notification::isLetterNotification)
-                .map(notification -> ((LetterNotification) notification).getLetterId())
-                .toList();
     }
 
     public List<NotificationResponseDTO> createDTO() {

--- a/src/main/java/postman/bottler/notification/dto/request/NotificationRequestDTO.java
+++ b/src/main/java/postman/bottler/notification/dto/request/NotificationRequestDTO.java
@@ -10,7 +10,9 @@ public record NotificationRequestDTO(
         @NotNull(message = "알림 대상은 필수입니다.")
         Long receiver,
 
-        Long letterId
+        Long letterId,
+
+        String label
 ) {
 
 }

--- a/src/main/java/postman/bottler/notification/infra/NotificationHashKey.java
+++ b/src/main/java/postman/bottler/notification/infra/NotificationHashKey.java
@@ -10,7 +10,8 @@ public enum NotificationHashKey {
     RECEIVER("receiver"),
     CREATED_AT("created_at"),
     LETTER_ID("letter_id"),
-    IS_READ("is_read");
+    IS_READ("is_read"),
+    LABEL("label");
 
     private final String key;
 

--- a/src/main/java/postman/bottler/notification/infra/RedisNotification.java
+++ b/src/main/java/postman/bottler/notification/infra/RedisNotification.java
@@ -3,6 +3,7 @@ package postman.bottler.notification.infra;
 import static postman.bottler.notification.infra.NotificationHashKey.CREATED_AT;
 import static postman.bottler.notification.infra.NotificationHashKey.ID;
 import static postman.bottler.notification.infra.NotificationHashKey.IS_READ;
+import static postman.bottler.notification.infra.NotificationHashKey.LABEL;
 import static postman.bottler.notification.infra.NotificationHashKey.LETTER_ID;
 import static postman.bottler.notification.infra.NotificationHashKey.RECEIVER;
 import static postman.bottler.notification.infra.NotificationHashKey.TYPE;
@@ -37,6 +38,8 @@ public class RedisNotification {
 
     private Boolean isRead;
 
+    private String label;
+
     public static RedisNotification from(Notification notification) {
         return RedisNotification.builder()
                 .id(notification.getId())
@@ -46,11 +49,12 @@ public class RedisNotification {
                         ((LetterNotification) notification).getLetterId() : null)
                 .createdAt(notification.getCreatedAt())
                 .isRead(notification.getIsRead())
+                .label(notification.isLetterNotification() ? ((LetterNotification) notification).getLabel() : null)
                 .build();
     }
 
     public Notification toDomain() {
-        return Notification.of(id, type, receiver, letterId, createdAt, isRead);
+        return Notification.of(id, type, receiver, letterId, createdAt, isRead, label);
     }
 
     public Map<String, Object> toMap() {
@@ -61,6 +65,7 @@ public class RedisNotification {
         map.put(LETTER_ID.getKey(), letterId);
         map.put(CREATED_AT.getKey(), createdAt);
         map.put(IS_READ.getKey(), isRead);
+        map.put(LABEL.getKey(), label);
         return map;
     }
 
@@ -72,6 +77,7 @@ public class RedisNotification {
                 .createdAt((LocalDateTime) redisTemplate.opsForHash().get(key, CREATED_AT.getKey()))
                 .letterId((Long) redisTemplate.opsForHash().get(key, LETTER_ID.getKey()))
                 .isRead((Boolean) redisTemplate.opsForHash().get(key, IS_READ.getKey()))
+                .label((String) redisTemplate.opsForHash().get(key, LABEL.getKey()))
                 .build();
     }
 

--- a/src/main/java/postman/bottler/notification/service/NotificationService.java
+++ b/src/main/java/postman/bottler/notification/service/NotificationService.java
@@ -5,14 +5,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import postman.bottler.letter.service.LetterRepository;
-import postman.bottler.mapletter.service.MapLetterRepository;
 import postman.bottler.notification.domain.Notification;
 import postman.bottler.notification.domain.NotificationType;
 import postman.bottler.notification.domain.Notifications;
 import postman.bottler.notification.domain.PushMessages;
 import postman.bottler.notification.domain.Subscriptions;
-import postman.bottler.notification.dto.request.NotificationLabelRequestDTO;
 import postman.bottler.notification.dto.request.RecommendNotificationRequestDTO;
 import postman.bottler.notification.dto.response.NotificationResponseDTO;
 
@@ -24,12 +21,9 @@ public class NotificationService {
     private final SubscriptionRepository subscriptionRepository;
     private final PushNotificationProvider pushNotificationProvider;
 
-    private final MapLetterRepository mapLetterRepository;
-    private final LetterRepository keywordLetterRepository;
-
     @Transactional
-    public NotificationResponseDTO sendNotification(NotificationType type, Long userId, Long letterId) {
-        Notification notification = Notification.create(type, userId, letterId);
+    public NotificationResponseDTO sendNotification(NotificationType type, Long userId, Long letterId, String label) {
+        Notification notification = Notification.create(type, userId, letterId, label);
         Subscriptions subscriptions = subscriptionRepository.findByUserId(userId);
         NotificationResponseDTO result = NotificationResponseDTO.from(notificationRepository.save(notification));
         if (subscriptions.isPushEnabled()) {
@@ -42,14 +36,6 @@ public class NotificationService {
     @Transactional
     public List<NotificationResponseDTO> getUserNotifications(Long userId) {
         Notifications notifications = notificationRepository.findByReceiver(userId);
-        List<Long> mapIds = notifications.extractMapIds();
-        List<NotificationLabelRequestDTO> mapLabels = mapLetterRepository.findAllByIds(mapIds).stream()
-                .map(letter -> new NotificationLabelRequestDTO(letter.getId(), letter.getLabel())).toList();
-        notifications.setMapLabels(mapLabels);
-        List<Long> keywordIds = notifications.extractKeywordIds();
-        List<NotificationLabelRequestDTO> keywordLabels = keywordLetterRepository.findAllByIds(keywordIds)
-                .stream().map(letter -> new NotificationLabelRequestDTO(letter.getId(), letter.getLabel())).toList();
-        notifications.setKeywordLabels(keywordLabels);
         notifications.orderByCreatedAt();
         List<NotificationResponseDTO> result = notifications.createDTO();
         notificationRepository.updateNotifications(notifications.markAsRead());
@@ -60,7 +46,7 @@ public class NotificationService {
     public void sendKeywordNotifications(List<RecommendNotificationRequestDTO> requests) {
         requests.forEach(request -> {
             notificationRepository.save(Notification.create(NotificationType.NEW_LETTER, request.userId(),
-                    request.letterId()));
+                    request.letterId(), request.label()));
         });
         Subscriptions allSubscriptions = subscriptionRepository.findAll();
         if (allSubscriptions.isPushEnabled()) {

--- a/src/main/java/postman/bottler/user/service/UserService.java
+++ b/src/main/java/postman/bottler/user/service/UserService.java
@@ -13,6 +13,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import postman.bottler.notification.domain.NotificationType;
+import postman.bottler.notification.service.NotificationService;
 import postman.bottler.slack.SlackConstant;
 import postman.bottler.slack.SlackService;
 import postman.bottler.user.auth.JwtTokenProvider;
@@ -45,6 +47,7 @@ public class UserService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final EmailService emailService;
     private final SlackService slackService;
+    private final NotificationService notificationService;
 
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     private static final int CODE_LENGTH = 8;
@@ -242,6 +245,7 @@ public class UserService {
         if (user.checkBan()) {
             banService.banUser(user);
             slackService.sendSlackMessage(SlackConstant.BAN, userId);
+            notificationService.sendNotification(NotificationType.BAN, userId, null, null);
         }
         userRepository.updateWarningCount(user);
     }

--- a/src/test/java/postman/bottler/notification/domain/LetterNotificationTest.java
+++ b/src/test/java/postman/bottler/notification/domain/LetterNotificationTest.java
@@ -10,7 +10,7 @@ public class LetterNotificationTest {
     @Test
     @DisplayName("편지 알림 생성 시, 편지 ID가 존재하지 않는 경우, 예외를 발생시킨다.")
     public void createLetterNotificationWithNonLetter() {
-        Assertions.assertThatThrownBy(() -> Notification.create(NotificationType.NEW_LETTER, 1L, null))
+        Assertions.assertThatThrownBy(() -> Notification.create(NotificationType.NEW_LETTER, 1L, null, null))
                 .isInstanceOf(NoLetterIdException.class);
     }
 }

--- a/src/test/java/postman/bottler/notification/domain/NotificationTest.java
+++ b/src/test/java/postman/bottler/notification/domain/NotificationTest.java
@@ -17,11 +17,11 @@ public class NotificationTest {
     @DisplayName("잘못된 편지 타입 요청 시, NoTypeException을 발생시킨다.")
     public void wrongType() {
         // GIVEN
-        NotificationRequestDTO wrong = new NotificationRequestDTO("WRONG", 1L, 1L);
+        NotificationRequestDTO wrong = new NotificationRequestDTO("WRONG", 1L, 1L, null);
 
         // WHEN - THEN
         assertThatThrownBy(() -> Notification.create(NotificationType.from(wrong.notificationType()), wrong.receiver(),
-                wrong.letterId()))
+                wrong.letterId(), wrong.label()))
                 .isInstanceOf(NoTypeException.class);
     }
 
@@ -32,11 +32,11 @@ public class NotificationTest {
         @DisplayName("새 편지 알림을 생성한다.")
         public void newLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("NEW_LETTER", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("NEW_LETTER", 1L, 1L, "label");
 
             // WHEN
-            Notification notification = Notification.create(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId(), request.label());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.NEW_LETTER);
@@ -49,12 +49,12 @@ public class NotificationTest {
         @DisplayName("새 편지 생성 시, 편지 ID가 없으면 예외를 발생시킨다.")
         public void newLetterNoLetterIdTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("NEW_LETTER", 1L, null);
+            NotificationRequestDTO request = new NotificationRequestDTO("NEW_LETTER", 1L, null, null);
 
             // WHEN
             assertThatThrownBy(
                     () -> Notification.create(NotificationType.from(request.notificationType()), request.receiver(),
-                            request.letterId()))
+                            request.letterId(), request.label()))
                     .isInstanceOf(NoLetterIdException.class);
         }
 
@@ -62,11 +62,11 @@ public class NotificationTest {
         @DisplayName("타겟 편지 알림을 생성한다.")
         public void targetLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("TARGET_LETTER", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("TARGET_LETTER", 1L, 1L, "label");
 
             // WHEN
-            Notification notification = Notification.create(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId(), request.label());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.TARGET_LETTER);
@@ -79,12 +79,12 @@ public class NotificationTest {
         @DisplayName("타겟 편지 생성 시, 편지 ID가 없으면 예외를 발생시킨다.")
         public void targetLetterNoLetterIdTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("TARGET_LETTER", 1L, null);
+            NotificationRequestDTO request = new NotificationRequestDTO("TARGET_LETTER", 1L, null, null);
 
             // WHEN
             assertThatThrownBy(
                     () -> Notification.create(NotificationType.from(request.notificationType()), request.receiver(),
-                            request.letterId()))
+                            request.letterId(), request.label()))
                     .isInstanceOf(NoLetterIdException.class);
         }
 
@@ -92,11 +92,11 @@ public class NotificationTest {
         @DisplayName("지도 편지 답장 알림을 생성한다.")
         public void replyMapLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("MAP_REPLY", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("MAP_REPLY", 1L, 1L, null);
 
             // WHEN
-            Notification notification = Notification.create(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId(), null);
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.MAP_REPLY);
@@ -109,11 +109,11 @@ public class NotificationTest {
         @DisplayName("키워드 편지 답장 알림을 생성한다.")
         public void replyKeywordLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, 1L, null);
 
             // WHEN
-            Notification notification = Notification.create(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId(), request.label());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.KEYWORD_REPLY);
@@ -127,12 +127,12 @@ public class NotificationTest {
         @DisplayName("새 편지 생성 시, 편지 ID가 없으면 예외를 발생시킨다.")
         public void replyLetterNoLetterIdTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, null);
+            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, null, null);
 
             // WHEN
             assertThatThrownBy(
                     () -> Notification.create(NotificationType.from(request.notificationType()), request.receiver(),
-                            request.letterId()))
+                            request.letterId(), request.label()))
                     .isInstanceOf(NoLetterIdException.class);
         }
 
@@ -140,11 +140,11 @@ public class NotificationTest {
         @DisplayName("유저 경고 알림을 생성한다.")
         public void warningNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("WARNING", 1L, null);
+            NotificationRequestDTO request = new NotificationRequestDTO("WARNING", 1L, null, null);
 
             // WHEN
-            Notification notification = Notification.create(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId(), request.label());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.WARNING);
@@ -156,11 +156,11 @@ public class NotificationTest {
         @DisplayName("유저 정지 알림을 생성한다.")
         public void banNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("BAN", 1L, null);
+            NotificationRequestDTO request = new NotificationRequestDTO("BAN", 1L, null, null);
 
             // WHEN
-            Notification notification = Notification.create(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+            Notification notification = Notification.create(NotificationType.from(request.notificationType()),
+                    request.receiver(), request.letterId(), request.label());
 
             // THEN
             assertThat(notification.getType()).isEqualTo(NotificationType.BAN);
@@ -176,7 +176,7 @@ public class NotificationTest {
         @DisplayName("알림을 읽는다면, 읽음 표시를 한다.")
         public void readNotification() {
             // GIVEN
-            Notification notification = Notification.create(NotificationType.NEW_LETTER, 1L, 1L);
+            Notification notification = Notification.create(NotificationType.NEW_LETTER, 1L, 1L, "label");
 
             // WHEN
             Notification read = notification.read();

--- a/src/test/java/postman/bottler/notification/service/NotificationServiceTest.java
+++ b/src/test/java/postman/bottler/notification/service/NotificationServiceTest.java
@@ -42,149 +42,156 @@ public class NotificationServiceTest {
         @DisplayName("새 편지 알림을 보낸다.")
         public void sendNewLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("NEW_LETTER", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("NEW_LETTER", 1L, 1L, "label");
             Notification notification = Notification.create(NotificationType.from(request.notificationType()),
-                    request.receiver(), request.letterId());
+                    request.receiver(), request.letterId(), request.label());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    NotificationType.from(request.notificationType()),
-                    request.receiver(),
-                    request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId(),
+                    request.label());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
             assertThat(response.type()).isEqualTo(NotificationType.NEW_LETTER);
             assertThat(response.letterId()).isEqualTo(1L);
+            assertThat(response.label()).isEqualTo(request.label());
         }
 
         @Test
         @DisplayName("타겟 편지 알림을 보낸다.")
         public void sendTargetLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("TARGET_LETTER", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("TARGET_LETTER", 1L, 1L, "label");
             Notification notification = Notification.create(NotificationType.from(request.notificationType()),
-                    request.receiver(), request.letterId());
+                    request.receiver(), request.letterId(), request.label());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId(),
+                    request.label());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
             assertThat(response.type()).isEqualTo(NotificationType.TARGET_LETTER);
             assertThat(response.letterId()).isEqualTo(1L);
+            assertThat(response.label()).isEqualTo(request.label());
         }
 
         @Test
         @DisplayName("지도 답장 편지 알림을 보낸다.")
         public void sendMapReplyLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("MAP_REPLY", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("MAP_REPLY", 1L, 1L, "label");
             Notification notification = Notification.create(NotificationType.from(request.notificationType()),
-                    request.receiver(), request.letterId());
+                    request.receiver(), request.letterId(), request.label());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId(),
+                    request.label());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
             assertThat(response.type()).isEqualTo(NotificationType.MAP_REPLY);
             assertThat(response.letterId()).isEqualTo(1L);
+            assertThat(response.label()).isNull();
         }
 
         @Test
         @DisplayName("키워드 답장 편지 알림을 보낸다.")
         public void sendKeywordReplyLetterNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("KEYWORD_REPLY", 1L, 1L, "label");
             Notification notification = Notification.create(NotificationType.from(request.notificationType()),
-                    request.receiver(), request.letterId());
+                    request.receiver(), request.letterId(), request.label());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId(),
+                    request.label());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
             assertThat(response.type()).isEqualTo(NotificationType.KEYWORD_REPLY);
             assertThat(response.letterId()).isEqualTo(1L);
+            assertThat(response.label()).isNull();
         }
 
         @Test
         @DisplayName("경고 알림을 보낸다.")
         public void sendWarningNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("WARNING", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("WARNING", 1L, 1L, "label");
             Notification notification = Notification.create(NotificationType.from(request.notificationType()),
-                    request.receiver(), request.letterId());
+                    request.receiver(), request.letterId(), request.label());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId(),
+                    request.label());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
             assertThat(response.type()).isEqualTo(NotificationType.WARNING);
             assertThat(response.letterId()).isNull();
+            assertThat(response.label()).isNull();
         }
 
         @Test
         @DisplayName("경고 알림을 보낸다.")
         public void sendBanNotificationTest() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("BAN", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("BAN", 1L, 1L, "label");
             Notification notification = Notification.create(NotificationType.from(request.notificationType()),
-                    request.receiver(), request.letterId());
+                    request.receiver(), request.letterId(), request.label());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of(Subscription.create(1L, "token"))));
 
             // WHEN
             NotificationResponseDTO response = notificationService.sendNotification(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId(),
+                    request.label());
 
             // THEN
             assertThat(response.receiver()).isEqualTo(1L);
             assertThat(response.type()).isEqualTo(NotificationType.BAN);
             assertThat(response.letterId()).isNull();
+            assertThat(response.label()).isNull();
         }
 
         @Test
         @DisplayName("알림 보낼 기기가 없다면, 보내지 않는다.")
         public void notSendPushNotification() {
             // GIVEN
-            NotificationRequestDTO request = new NotificationRequestDTO("BAN", 1L, 1L);
+            NotificationRequestDTO request = new NotificationRequestDTO("BAN", 1L, 1L, "label");
             Notification notification = Notification.create(NotificationType.from(request.notificationType()),
-                    request.receiver(), request.letterId());
+                    request.receiver(), request.letterId(), request.label());
             when(notificationRepository.save(any())).thenReturn(notification);
             when(subscriptionRepository.findByUserId(1L))
                     .thenReturn(Subscriptions.from(List.of()));
 
             // WHEN
-            NotificationResponseDTO response = notificationService.sendNotification(
-                    NotificationType.from(request.notificationType()), request.receiver(), request.letterId());
+            notificationService.sendNotification(NotificationType.from(request.notificationType()), request.receiver(),
+                    request.letterId(), request.label());
 
             // THEN
-            assertThat(response.receiver()).isEqualTo(1L);
-            assertThat(response.type()).isEqualTo(NotificationType.BAN);
-            assertThat(response.letterId()).isNull();
             verify(pushNotificationProvider, times(0)).pushAll(any());
         }
     }
@@ -197,12 +204,12 @@ public class NotificationServiceTest {
         public void getNotifications() {
             // GIVEN
             ArrayList<Notification> notifications = new ArrayList<>();
-            notifications.add(Notification.create(NotificationType.from("NEW_LETTER"), 1L, 1L));
-            notifications.add(Notification.create(NotificationType.from("TARGET_LETTER"), 1L, 1L));
-            notifications.add(Notification.create(NotificationType.from("MAP_REPLY"), 1L, 1L));
-            notifications.add(Notification.create(NotificationType.from("KEYWORD_REPLY"), 1L, 1L));
-            notifications.add(Notification.create(NotificationType.from("WARNING"), 1L, null));
-            notifications.add(Notification.create(NotificationType.from("BAN"), 1L, null));
+            notifications.add(Notification.create(NotificationType.from("NEW_LETTER"), 1L, 1L, "label"));
+            notifications.add(Notification.create(NotificationType.from("TARGET_LETTER"), 1L, 1L, "label"));
+            notifications.add(Notification.create(NotificationType.from("MAP_REPLY"), 1L, 1L, null));
+            notifications.add(Notification.create(NotificationType.from("KEYWORD_REPLY"), 1L, 1L, null));
+            notifications.add(Notification.create(NotificationType.from("WARNING"), 1L, null, null));
+            notifications.add(Notification.create(NotificationType.from("BAN"), 1L, null, null));
 
             Notifications notReadNotification = Notifications.from(notifications);
 


### PR DESCRIPTION
## 📢 기능 설명 

- 알림 서비스에서 편지 서비스 관련 의존성을 제거하였습니다.
- 타 도메인에서 알림 요청을 추가하였습니다.

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #165 
close #166 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
