### PR TITLE
Fix/#235 map letter fix

### DIFF
--- a/src/main/java/postman/bottler/global/response/code/ErrorStatus.java
+++ b/src/main/java/postman/bottler/global/response/code/ErrorStatus.java
@@ -76,7 +76,10 @@ public enum ErrorStatus {
     LETTER_ALREADY_ARCHIVED(HttpStatus.BAD_REQUEST, "MAP4009"),
     LETTER_ALREADY_REPLY(HttpStatus.BAD_REQUEST, "MAP40010"),
     DISTANCE_TOO_FAR(HttpStatus.BAD_REQUEST, "MAP40011"),
-    LETTER_BLOCKED(HttpStatus.BAD_REQUEST, "MAP40012");
+    LETTER_BLOCKED(HttpStatus.BAD_REQUEST, "MAP40012"),
+    TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MAP40013"),
+
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/OneLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/OneLetterResponseDTO.java
@@ -15,9 +15,12 @@ public record OneLetterResponseDTO(
         String paper,
         String label,
         LocalDateTime createdAt,
-        boolean isOwner
+        boolean isOwner,
+        boolean isReplied,
+        boolean isArchived
 ) {
-    public static OneLetterResponseDTO from(MapLetter mapLetter, String profileImg, boolean isOwner) {
+    public static OneLetterResponseDTO from(MapLetter mapLetter, String profileImg, boolean isOwner, boolean isReplied,
+                                            boolean isArchived) {
         return OneLetterResponseDTO.builder()
                 .title(mapLetter.getTitle())
                 .content(mapLetter.getContent())
@@ -28,6 +31,8 @@ public record OneLetterResponseDTO(
                 .createdAt(mapLetter.getCreatedAt())
                 .description(mapLetter.getDescription())
                 .isOwner(isOwner)
+                .isReplied(isReplied)
+                .isArchived(isArchived)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -296,6 +296,9 @@ public class MapLetterService {
         validMinPage(page);
         Page<ReplyMapLetter> letters = replyMapLetterRepository.findAllSentReplyByUserId(userId,
                 PageRequest.of(page - 1, size));
+        if(letters.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        }
         validMaxPage(letters.getTotalPages(), page);
 
         return letters.map(replyMapLetter -> {

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -112,8 +112,8 @@ public class MapLetterService {
         Page<FindSentMapLetter> sentMapLetters = mapLetterRepository.findSentLettersByUserId(userId,
                 PageRequest.of(page - 1, size));
 
-        if(sentMapLetters.isEmpty()){
-            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        if (sentMapLetters.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page - 1, size), 0);
         }
 
         validMaxPage(sentMapLetters.getTotalPages(), page);
@@ -136,8 +136,8 @@ public class MapLetterService {
         Page<FindReceivedMapLetterDTO> letters = mapLetterRepository.findActiveReceivedMapLettersByUserId(userId,
                 PageRequest.of(page - 1, size));
 
-        if(letters.isEmpty()){
-            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        if (letters.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page - 1, size), 0);
         }
 
         validMaxPage(letters.getTotalPages(), page);
@@ -197,8 +197,8 @@ public class MapLetterService {
         Page<ReplyMapLetter> findReply = replyMapLetterRepository.findReplyMapLettersBySourceLetterId(letterId,
                 PageRequest.of(page - 1, size));
 
-        if(findReply.isEmpty()){
-            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        if (findReply.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page - 1, size), 0);
         }
 
         validMaxPage(findReply.getTotalPages(), page);
@@ -239,8 +239,8 @@ public class MapLetterService {
         Page<FindAllArchiveLetters> letters = mapLetterArchiveRepository.findAllById(userId,
                 PageRequest.of(page - 1, size));
 
-        if(letters.isEmpty()){
-            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        if (letters.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page - 1, size), 0);
         }
 
         validMaxPage(letters.getTotalPages(), page);
@@ -296,8 +296,8 @@ public class MapLetterService {
         validMinPage(page);
         Page<ReplyMapLetter> letters = replyMapLetterRepository.findAllSentReplyByUserId(userId,
                 PageRequest.of(page - 1, size));
-        if(letters.isEmpty()){
-            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        if (letters.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page - 1, size), 0);
         }
         validMaxPage(letters.getTotalPages(), page);
 
@@ -312,8 +312,8 @@ public class MapLetterService {
     public Page<FindAllSentMapLetterResponseDTO> findAllSentMapLetter(int page, int size, Long userId) {
         validMinPage(page);
         Page<MapLetter> letters = mapLetterRepository.findActiveByCreateUserId(userId, PageRequest.of(page - 1, size));
-        if(letters.isEmpty()){
-            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        if (letters.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page - 1, size), 0);
         }
         validMaxPage(letters.getTotalPages(), page);
 
@@ -331,8 +331,8 @@ public class MapLetterService {
         Page<ReplyMapLetter> letters = replyMapLetterRepository.findActiveReplyMapLettersBySourceUserId(userId,
                 PageRequest.of(page - 1, size));
 
-        if(letters.isEmpty()){
-            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        if (letters.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page - 1, size), 0);
         }
 
         validMaxPage(letters.getTotalPages(), page);
@@ -347,8 +347,8 @@ public class MapLetterService {
     public Page<FindAllReceivedLetterResponseDTO> findAllReceivedLetter(int page, int size, Long userId) {
         validMinPage(page);
         Page<MapLetter> letters = mapLetterRepository.findActiveByTargetUserId(userId, PageRequest.of(page - 1, size));
-        if(letters.isEmpty()){
-            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        if (letters.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page - 1, size), 0);
         }
         validMaxPage(letters.getTotalPages(), page);
         return letters.map(letter -> {

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -197,6 +197,10 @@ public class MapLetterService {
         Page<ReplyMapLetter> findReply = replyMapLetterRepository.findReplyMapLettersBySourceLetterId(letterId,
                 PageRequest.of(page - 1, size));
 
+        if(findReply.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        }
+
         validMaxPage(findReply.getTotalPages(), page);
 
         return findReply.map(FindAllReplyMapLettersResponseDTO::from);

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -324,6 +324,11 @@ public class MapLetterService {
         validMinPage(page);
         Page<ReplyMapLetter> letters = replyMapLetterRepository.findActiveReplyMapLettersBySourceUserId(userId,
                 PageRequest.of(page - 1, size));
+
+        if(letters.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        }
+
         validMaxPage(letters.getTotalPages(), page);
 
         return letters.map(replyMapLetter -> {

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -238,6 +238,11 @@ public class MapLetterService {
         validMinPage(page);
         Page<FindAllArchiveLetters> letters = mapLetterArchiveRepository.findAllById(userId,
                 PageRequest.of(page - 1, size));
+
+        if(letters.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        }
+
         validMaxPage(letters.getTotalPages(), page);
         return letters;
     }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -341,6 +341,9 @@ public class MapLetterService {
     public Page<FindAllReceivedLetterResponseDTO> findAllReceivedLetter(int page, int size, Long userId) {
         validMinPage(page);
         Page<MapLetter> letters = mapLetterRepository.findActiveByTargetUserId(userId, PageRequest.of(page - 1, size));
+        if(letters.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        }
         validMaxPage(letters.getTotalPages(), page);
         return letters.map(letter -> {
             String sendUserNickname = userService.getNicknameById(letter.getCreateUserId());

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -135,6 +135,11 @@ public class MapLetterService {
         validMinPage(page);
         Page<FindReceivedMapLetterDTO> letters = mapLetterRepository.findActiveReceivedMapLettersByUserId(userId,
                 PageRequest.of(page - 1, size));
+
+        if(letters.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        }
+
         validMaxPage(letters.getTotalPages(), page);
 
         return letters.map(letter -> {

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -94,7 +94,8 @@ public class MapLetterService {
         mapLetter.validateAccess(userId);
 
         String profileImg = userService.getProfileImageUrlById(mapLetter.getCreateUserId());
-        return OneLetterResponseDTO.from(mapLetter, profileImg, userId == mapLetter.getCreateUserId(), );
+        return OneLetterResponseDTO.from(mapLetter, profileImg, mapLetter.getCreateUserId() == userId,
+                checkReplyMapLetter(letterId, userId).isReplied(), isArchived(letterId, userId));
     }
 
     @Transactional

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -110,6 +111,11 @@ public class MapLetterService {
         validMinPage(page);
         Page<FindSentMapLetter> sentMapLetters = mapLetterRepository.findSentLettersByUserId(userId,
                 PageRequest.of(page - 1, size));
+
+        if(sentMapLetters.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        }
+
         validMaxPage(sentMapLetters.getTotalPages(), page);
 
         return sentMapLetters.map(this::toFindSentMapLetter);

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -309,6 +309,9 @@ public class MapLetterService {
     public Page<FindAllSentMapLetterResponseDTO> findAllSentMapLetter(int page, int size, Long userId) {
         validMinPage(page);
         Page<MapLetter> letters = mapLetterRepository.findActiveByCreateUserId(userId, PageRequest.of(page - 1, size));
+        if(letters.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), PageRequest.of(page-1, size), 0);
+        }
         validMaxPage(letters.getTotalPages(), page);
 
         return letters.map(mapLetter -> {

--- a/src/main/java/postman/bottler/mapletter/exception/MapLetterExceptionHandler.java
+++ b/src/main/java/postman/bottler/mapletter/exception/MapLetterExceptionHandler.java
@@ -93,4 +93,10 @@ public class MapLetterExceptionHandler {
         log.error(e.getMessage());
         return ApiResponse.onFailure(ErrorStatus.PAGINATION_VALIDATION_ERROR.getCode(), e.getMessage(), null);
     }
+
+    @ExceptionHandler(TypeNotFoundException.class)
+    public ApiResponse<?> handleTypeNotFoundException(TypeNotFoundException e) {
+        log.error(e.getMessage());
+        return ApiResponse.onFailure(ErrorStatus.TYPE_NOT_FOUND.getCode(), e.getMessage(), null);
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/exception/TypeNotFoundException.java
+++ b/src/main/java/postman/bottler/mapletter/exception/TypeNotFoundException.java
@@ -1,0 +1,7 @@
+package postman.bottler.mapletter.exception;
+
+public class TypeNotFoundException extends RuntimeException {
+    public TypeNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -42,6 +42,7 @@ import postman.bottler.mapletter.exception.EmptyMapLetterTitleException;
 import postman.bottler.mapletter.exception.EmptyReplyMapLetterSourceException;
 import postman.bottler.mapletter.exception.LocationNotFoundException;
 import postman.bottler.mapletter.application.service.MapLetterService;
+import postman.bottler.mapletter.exception.TypeNotFoundException;
 import postman.bottler.user.auth.CustomUserDetails;
 
 @RestController
@@ -124,26 +125,26 @@ public class MapLetterController {
         return ApiResponse.onDeleteSuccess(letters);
     }
 
-    @GetMapping("/sent")
-    @Operation(summary = "보낸 편지 전체 조회", description = "로그인 필수. 내가 보낸 편지, 답장 전체 조회. 페이징 처리(1페이지부터). ")
-    public ApiResponse<MapLetterPageResponseDTO<FindMapLetterResponseDTO>> findSentMapLetters(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        return ApiResponse.onSuccess(
-                MapLetterPageResponseDTO.from(mapLetterService.findSentMapLetters(page, size, userId)));
-    }
+//    @GetMapping("/sent")
+//    @Operation(summary = "보낸 편지 전체 조회", description = "로그인 필수. 내가 보낸 편지, 답장 전체 조회. 페이징 처리(1페이지부터). ")
+//    public ApiResponse<MapLetterPageResponseDTO<FindMapLetterResponseDTO>> findSentMapLetters(
+//            @RequestParam(defaultValue = "1") int page,
+//            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
+//        Long userId = userDetails.getUserId();
+//        return ApiResponse.onSuccess(
+//                MapLetterPageResponseDTO.from(mapLetterService.findSentMapLetters(page, size, userId)));
+//    }
 
-    @GetMapping("/received")
-    @Operation(summary = "받은 편지 전체 조회", description = "로그인 필수. 내가 타겟인 편지, 나에게 온 답장 전체 조회. 페이징 처리(1페이지부터)")
-    public ApiResponse<MapLetterPageResponseDTO<FindReceivedMapLetterResponseDTO>> findReceivedMapLetters(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "9") int size,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        return ApiResponse.onSuccess(
-                MapLetterPageResponseDTO.from(mapLetterService.findReceivedMapLetters(page, size, userId)));
-    }
+//    @GetMapping("/received")
+//    @Operation(summary = "받은 편지 전체 조회", description = "로그인 필수. 내가 타겟인 편지, 나에게 온 답장 전체 조회. 페이징 처리(1페이지부터)")
+//    public ApiResponse<MapLetterPageResponseDTO<FindReceivedMapLetterResponseDTO>> findReceivedMapLetters(
+//            @RequestParam(defaultValue = "1") int page,
+//            @RequestParam(defaultValue = "9") int size,
+//            @AuthenticationPrincipal CustomUserDetails userDetails) {
+//        Long userId = userDetails.getUserId();
+//        return ApiResponse.onSuccess(
+//                MapLetterPageResponseDTO.from(mapLetterService.findReceivedMapLetters(page, size, userId)));
+//    }
 
     @GetMapping
     @Operation(summary = "주변 편지 조회", description = "로그인 필수. 반경 500m 내 퍼블릭 편지, 나에게 타겟으로 온 편지 조회")
@@ -247,46 +248,46 @@ public class MapLetterController {
         return ApiResponse.onDeleteSuccess(letters);
     }
 
-    @GetMapping("/sent/reply")
-    @Operation(summary = "보낸 답장 편지 조회", description = "보낸 편지 조회에서 답장 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
-    public ApiResponse<MapLetterPageResponseDTO<FindAllSentReplyMapLetterResponseDTO>> findAllSentReplyMapLetter(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "9") int size,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        return ApiResponse.onSuccess(
-                MapLetterPageResponseDTO.from(mapLetterService.findAllSentReplyMapLetter(page, size, userId)));
-    }
+//    @GetMapping("/sent/reply")
+//    @Operation(summary = "보낸 답장 편지 조회", description = "보낸 편지 조회에서 답장 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
+//    public ApiResponse<MapLetterPageResponseDTO<FindAllSentReplyMapLetterResponseDTO>> findAllSentReplyMapLetter(
+//            @RequestParam(defaultValue = "1") int page,
+//            @RequestParam(defaultValue = "9") int size,
+//            @AuthenticationPrincipal CustomUserDetails userDetails) {
+//        Long userId = userDetails.getUserId();
+//        return ApiResponse.onSuccess(
+//                MapLetterPageResponseDTO.from(mapLetterService.findAllSentReplyMapLetter(page, size, userId)));
+//    }
 
-    @GetMapping("/sent/letter")
-    @Operation(summary = "보낸 지도 편지 조회", description = "보낸 편지 조회에서 지도 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
-    public ApiResponse<MapLetterPageResponseDTO<FindAllSentMapLetterResponseDTO>> findAllSentMapLetter(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        return ApiResponse.onSuccess(
-                MapLetterPageResponseDTO.from(mapLetterService.findAllSentMapLetter(page, size, userId)));
-    }
+//    @GetMapping("/sent/letter")
+//    @Operation(summary = "보낸 지도 편지 조회", description = "보낸 편지 조회에서 지도 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
+//    public ApiResponse<MapLetterPageResponseDTO<FindAllSentMapLetterResponseDTO>> findAllSentMapLetter(
+//            @RequestParam(defaultValue = "1") int page,
+//            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
+//        Long userId = userDetails.getUserId();
+//        return ApiResponse.onSuccess(
+//                MapLetterPageResponseDTO.from(mapLetterService.findAllSentMapLetter(page, size, userId)));
+//    }
 
-    @GetMapping("/received/reply")
-    @Operation(summary = "받은 답장 편지 조회", description = "받은 편지 조회에서 답장 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
-    public ApiResponse<MapLetterPageResponseDTO<FindAllReceivedReplyLetterResponseDTO>> findAllReceivedReplyMapLetter(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        return ApiResponse.onSuccess(
-                MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedReplyLetter(page, size, userId)));
-    }
+//    @GetMapping("/received/reply")
+//    @Operation(summary = "받은 답장 편지 조회", description = "받은 편지 조회에서 답장 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
+//    public ApiResponse<MapLetterPageResponseDTO<FindAllReceivedReplyLetterResponseDTO>> findAllReceivedReplyMapLetter(
+//            @RequestParam(defaultValue = "1") int page,
+//            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
+//        Long userId = userDetails.getUserId();
+//        return ApiResponse.onSuccess(
+//                MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedReplyLetter(page, size, userId)));
+//    }
 
-    @GetMapping("/received/letter")
-    @Operation(summary = "받은 타겟 편지 조회", description = "받은 편지 조회에서 타겟 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
-    public ApiResponse<MapLetterPageResponseDTO<FindAllReceivedLetterResponseDTO>> findAllReceivedMapLetter(
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        return ApiResponse.onSuccess(
-                MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedLetter(page, size, userId)));
-    }
+//    @GetMapping("/received/letter")
+//    @Operation(summary = "받은 타겟 편지 조회", description = "받은 편지 조회에서 타겟 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
+//    public ApiResponse<MapLetterPageResponseDTO<FindAllReceivedLetterResponseDTO>> findAllReceivedMapLetter(
+//            @RequestParam(defaultValue = "1") int page,
+//            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
+//        Long userId = userDetails.getUserId();
+//        return ApiResponse.onSuccess(
+//                MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedLetter(page, size, userId)));
+//    }
 
     @GetMapping("/guest")
     @Operation(summary = "로그인 하지 않은 유저 주변 편지 조회", description = "로그인 하지 않은 유저의 반경 500m 내 퍼블릭 편지 조회")
@@ -319,5 +320,35 @@ public class MapLetterController {
         }
 
         return ApiResponse.onSuccess(mapLetterService.guestFindOneMapLetter(letterId, lat, lon));
+    }
+
+    @GetMapping("/saved")
+    public ApiResponse<?> savedLetters(@RequestParam String type, @AuthenticationPrincipal CustomUserDetails user,
+                                       @RequestParam(defaultValue = "1") int page,
+                                       @RequestParam(defaultValue = "9") int size) {
+        Long userId = user.getUserId();
+        return switch (type) {
+            case "sent-all" -> //보낸 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(mapLetterService.findSentMapLetters(page, size, userId)));
+            case "sent-reply" -> //보낸 답장 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(
+                                    mapLetterService.findAllSentReplyMapLetter(page, size, userId)));
+            case "sent-map" -> //보낸 지도 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(mapLetterService.findAllSentMapLetter(page, size, userId)));
+            case "received-all" -> //받은 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(mapLetterService.findReceivedMapLetters(page, size, userId)));
+            case "received-reply" -> //받은 답장 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(
+                                    mapLetterService.findAllReceivedReplyLetter(page, size, userId)));
+            case "received-target" -> //받은 타겟 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedLetter(page, size, userId)));
+            default -> throw new TypeNotFoundException("올바르지 못한 타입입니다.");
+        };
     }
 }

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -328,7 +328,7 @@ public class MapLetterController {
                                        @RequestParam(defaultValue = "9") int size) {
         Long userId = user.getUserId();
         return switch (type) {
-            case "sent-all" -> //보낸 편지 전체 조회
+            case "sent-all" -> //보낸 편지 전체 조회(지도편지, 답장 편지)
                     ApiResponse.onSuccess(
                             MapLetterPageResponseDTO.from(mapLetterService.findSentMapLetters(page, size, userId)));
             case "sent-reply" -> //보낸 답장 편지 전체 조회
@@ -338,7 +338,7 @@ public class MapLetterController {
             case "sent-map" -> //보낸 지도 편지 전체 조회
                     ApiResponse.onSuccess(
                             MapLetterPageResponseDTO.from(mapLetterService.findAllSentMapLetter(page, size, userId)));
-            case "received-all" -> //받은 편지 전체 조회
+            case "received-all" -> //받은 편지 전체 조회(타겟 편지, 답장 편지)
                     ApiResponse.onSuccess(
                             MapLetterPageResponseDTO.from(mapLetterService.findReceivedMapLetters(page, size, userId)));
             case "received-reply" -> //받은 답장 편지 전체 조회


### PR DESCRIPTION
## 📢 기능 설명 

### 1차 스프린트 기간 API 수정

1.  `페이지네이션 데이터 없을 때 데이터 0개 내려주기`
```
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "content": [],
        "page": 1,
        "size": 9,
        "totalElements": 0,
        "totalPages": 0
    }
}
```
totalElements가 0으로 갑니다!

<br>

2. `/map/{letterId} : 편지 상세 조회 - 답장 여부 boolean, 보관 여부 boolean`
3. `/map/archive/{letterId} : 마이페이지에 있는 편지 상세 조회 - 답장 여부 boolean, 보관 여부 boolean`
<br>

4. `보관함 편지 api 쿼리 파라미터로 수정`
	- /api/map/saved?type = sent || reply || all
```
- /api/map/saved?type= 아래 확인해주세요! (페이징 처리 동일)
"sent-all" -> //보낸 편지 전체 조회(지도편지, 답장 편지)
"sent-reply" -> //보낸 답장 편지 전체 조회
"sent-map" -> //보낸 지도 편지 전체 조회
"received-all" -> //받은 편지 전체 조회(타겟 편지, 답장 편지)
"received-reply" -> //받은 답장 편지 전체 조회
"received-target" -> //받은 타겟 편지 전체 조회
```
<br>

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #235 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?

## ETC
일단 4번을 저렇게 수정하기는 했는데, 기존에 요청했던 것(all, reply, sent)보다 많아져서 이게 맞는지 모르겠네요... 기존 코드는 혹시 몰라서 주석 처리 했습니다. 회의, 배포 후 잘 동작 하면 주석 지우면 될 것 같습니다...!!