### PR TITLE
Feature/#248: request/response 로그 추가

### DIFF
--- a/src/main/java/postman/bottler/global/aop/LogAspect.java
+++ b/src/main/java/postman/bottler/global/aop/LogAspect.java
@@ -1,0 +1,64 @@
+package postman.bottler.global.aop;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.CodeSignature;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import postman.bottler.user.auth.CustomUserDetails;
+
+@Aspect
+@Slf4j
+@Component
+public class LogAspect {
+
+    @Pointcut("execution(public * postman.bottler.*.presentation..*Controller.*(..))")
+    public void controllerPointcut() {
+    }
+
+    @Pointcut("execution(public * postman.bottler.*.exception.*Handler.*(..))")
+    public void exceptionPointcut() {
+    }
+
+    @Before("controllerPointcut()")
+    public void logAround(JoinPoint joinPoint) {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = principal instanceof CustomUserDetails ? ((CustomUserDetails) principal).getUserId().toString()
+                : "none";
+
+        log.info("Request : {} (UserId={}) {}\n{}", request.getMethod(), userId, request.getRequestURI(),
+                params(joinPoint));
+    }
+
+    @AfterReturning(value = "controllerPointcut() || exceptionPointcut()", returning = "returnObj")
+    public void logAfterReturning(JoinPoint joinPoint, Object returnObj) {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = principal instanceof CustomUserDetails ? ((CustomUserDetails) principal).getUserId().toString()
+                : "none";
+
+        log.info("Response : {} (UserId={})\n{}", request.getRequestURI(), userId, returnObj);
+    }
+
+    private Map<String, Object> params(JoinPoint joinPoint) {
+        String[] parameterNames = ((CodeSignature) joinPoint.getSignature()).getParameterNames();
+        Object[] args = joinPoint.getArgs();
+        Map<String, Object> params = new HashMap<>();
+        for (int i = 0; i < parameterNames.length; i++) {
+            params.put(parameterNames[i], args[i]);
+        }
+        return params;
+    }
+}

--- a/src/main/java/postman/bottler/global/response/ApiResponse.java
+++ b/src/main/java/postman/bottler/global/response/ApiResponse.java
@@ -6,11 +6,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 import postman.bottler.global.response.code.SuccessStatus;
 
 @Getter
 @AllArgsConstructor
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@ToString
 public class ApiResponse<T> {
 
     @JsonProperty("isSuccess")


### PR DESCRIPTION
## 📢 기능 설명 

Request/Response 로그를 기록합니다.
- request
  - HTTP 메서드
  - URI
  - 유저 ID
  - 요청값
- response
  - URI
  - 유저 ID
  - 응답값

![image](https://github.com/user-attachments/assets/2ab9a633-4455-446a-92b3-3865722d9a8c)


## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #248
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
