### PR TITLE
Fix/#251 2차 스프린트 기간 지도 편지 api 수정

### DIFF
--- a/src/main/java/postman/bottler/mapletter/application/dto/FindReceivedMapLetterDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/FindReceivedMapLetterDTO.java
@@ -23,4 +23,6 @@ public interface FindReceivedMapLetterDTO {
     LocalDateTime getCreatedAt();
 
     Long getSenderId();
+
+    Integer getIsRead();
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteMapLettersRequestDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteMapLettersRequestDTO.java
@@ -1,8 +1,30 @@
 package postman.bottler.mapletter.application.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.List;
+import postman.bottler.mapletter.exception.TypeNotFoundException;
 
 public record DeleteMapLettersRequestDTO(
-        List<Long> letterIds
+        List<LetterInfo> letters
 ) {
+    public enum LetterType {
+        REPLY, MAP;
+
+        @JsonCreator
+        public static LetterType from(String value) {
+            for (LetterType type : LetterType.values()) {
+                if (type.name().equals(value)) {
+                    return type;
+                }
+            }
+            throw new TypeNotFoundException("잘못된 편지 타입입니다.");
+        }
+    }
+
+    public record LetterInfo(
+            LetterType letterType,
+            Long letterId
+    ) {
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteMapLettersV1RequestDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteMapLettersV1RequestDTO.java
@@ -1,0 +1,8 @@
+package postman.bottler.mapletter.application.dto.request;
+
+import java.util.List;
+
+public record DeleteMapLettersV1RequestDTO(
+        List<Long> letterIds
+) {
+}

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllReceivedLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllReceivedLetterResponseDTO.java
@@ -17,7 +17,8 @@ public record FindAllReceivedLetterResponseDTO(
         String sendUserNickname,
         String sendUserProfileImg,
         LocalDateTime createdAt,
-        DeleteMapLettersRequestDTO.LetterType deleteType //삭제 타입
+        DeleteMapLettersRequestDTO.LetterType deleteType, //삭제 타입
+        boolean isRead //한 번이라도 읽었는지
 ) {
     public static FindAllReceivedLetterResponseDTO from(MapLetter mapLetter, String sendUserNickname,
                                                         String sendUserProfileImg,
@@ -33,6 +34,7 @@ public record FindAllReceivedLetterResponseDTO(
                 .sendUserProfileImg(sendUserProfileImg)
                 .createdAt(mapLetter.getCreatedAt())
                 .deleteType(deleteType)
+                .isRead(mapLetter.isRead())
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllReceivedLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllReceivedLetterResponseDTO.java
@@ -3,6 +3,7 @@ package postman.bottler.mapletter.application.dto.response;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
 import postman.bottler.mapletter.domain.MapLetter;
 
 @Builder
@@ -15,10 +16,12 @@ public record FindAllReceivedLetterResponseDTO(
         String label,
         String sendUserNickname,
         String sendUserProfileImg,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        DeleteMapLettersRequestDTO.LetterType deleteType //삭제 타입
 ) {
     public static FindAllReceivedLetterResponseDTO from(MapLetter mapLetter, String sendUserNickname,
-                                                        String sendUserProfileImg) {
+                                                        String sendUserProfileImg,
+                                                        DeleteMapLettersRequestDTO.LetterType deleteType) {
         return FindAllReceivedLetterResponseDTO.builder()
                 .letterId(mapLetter.getId())
                 .title(mapLetter.getTitle())
@@ -29,6 +32,7 @@ public record FindAllReceivedLetterResponseDTO(
                 .sendUserNickname(sendUserNickname)
                 .sendUserProfileImg(sendUserProfileImg)
                 .createdAt(mapLetter.getCreatedAt())
+                .deleteType(deleteType)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllReceivedReplyLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllReceivedReplyLetterResponseDTO.java
@@ -2,6 +2,7 @@ package postman.bottler.mapletter.application.dto.response;
 
 import java.time.LocalDateTime;
 import lombok.Builder;
+import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
 import postman.bottler.mapletter.domain.ReplyMapLetter;
 
 @Builder
@@ -10,15 +11,18 @@ public record FindAllReceivedReplyLetterResponseDTO(
         String title,
         String label,
         LocalDateTime createdAt,
-        Long sourceLetterId
+        Long sourceLetterId,
+        DeleteMapLettersRequestDTO.LetterType deleteType //삭제 타입
 ) {
-    public static FindAllReceivedReplyLetterResponseDTO from(ReplyMapLetter letterDTO, String title) {
+    public static FindAllReceivedReplyLetterResponseDTO from(ReplyMapLetter letterDTO, String title,
+                                                             DeleteMapLettersRequestDTO.LetterType deleteType) {
         return FindAllReceivedReplyLetterResponseDTO.builder()
                 .letterId(letterDTO.getReplyLetterId())
                 .title(title)
                 .label(letterDTO.getLabel())
                 .createdAt(letterDTO.getCreatedAt())
                 .sourceLetterId(letterDTO.getSourceLetterId())
+                .deleteType(deleteType)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllSentMapLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllSentMapLetterResponseDTO.java
@@ -3,6 +3,7 @@ package postman.bottler.mapletter.application.dto.response;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
 import postman.bottler.mapletter.domain.MapLetter;
 import postman.bottler.mapletter.domain.MapLetterType;
 
@@ -16,9 +17,11 @@ public record FindAllSentMapLetterResponseDTO(
         String label,
         String targetUserNickname,
         LocalDateTime createdAt,
-        String type //TARGET(타겟 편지), PUBLIC(퍼블릭 편지)
+        String type, //TARGET(타겟 편지), PUBLIC(퍼블릭 편지)
+        DeleteMapLettersRequestDTO.LetterType deleteType //삭제 타입
 ) {
-    public static FindAllSentMapLetterResponseDTO from(MapLetter mapLetter, String targetUserNickname) {
+    public static FindAllSentMapLetterResponseDTO from(MapLetter mapLetter, String targetUserNickname,
+                                                       DeleteMapLettersRequestDTO.LetterType deleteType) {
         return FindAllSentMapLetterResponseDTO.builder()
                 .letterId(mapLetter.getId())
                 .title(mapLetter.getTitle())
@@ -29,6 +32,7 @@ public record FindAllSentMapLetterResponseDTO(
                 .targetUserNickname(targetUserNickname)
                 .createdAt(mapLetter.getCreatedAt())
                 .type(mapLetter.getType() == MapLetterType.PRIVATE ? "TARGET" : "PUBLIC")
+                .deleteType(deleteType)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllSentReplyMapLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/FindAllSentReplyMapLetterResponseDTO.java
@@ -2,6 +2,7 @@ package postman.bottler.mapletter.application.dto.response;
 
 import java.time.LocalDateTime;
 import lombok.Builder;
+import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
 import postman.bottler.mapletter.domain.ReplyMapLetter;
 
 @Builder
@@ -10,15 +11,18 @@ public record FindAllSentReplyMapLetterResponseDTO(
         String title,
         Long sourceLetterId,
         LocalDateTime createdAt,
-        String label
+        String label,
+        DeleteMapLettersRequestDTO.LetterType deleteType //삭제 타입
 ) {
-    public static FindAllSentReplyMapLetterResponseDTO from(ReplyMapLetter replyMapLetter, String title) {
+    public static FindAllSentReplyMapLetterResponseDTO from(ReplyMapLetter replyMapLetter, String title,
+                                                            DeleteMapLettersRequestDTO.LetterType deleteType) {
         return FindAllSentReplyMapLetterResponseDTO.builder()
                 .letterId(replyMapLetter.getReplyLetterId())
                 .title(title)
                 .sourceLetterId(replyMapLetter.getSourceLetterId())
                 .createdAt(replyMapLetter.getCreatedAt())
                 .label(replyMapLetter.getLabel())
+                .deleteType(deleteType)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/FindMapLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/FindMapLetterResponseDTO.java
@@ -1,8 +1,13 @@
 package postman.bottler.mapletter.application.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.Builder;
+import org.hibernate.sql.Delete;
+import postman.bottler.mapletter.application.dto.FindReceivedMapLetterDTO;
 import postman.bottler.mapletter.application.dto.FindSentMapLetter;
+import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
+import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO.LetterType;
 
 @Builder
 public record FindMapLetterResponseDTO(
@@ -13,9 +18,11 @@ public record FindMapLetterResponseDTO(
         String targetUserNickname, // 타겟 편지의 경우만
         LocalDateTime createdAt,
         String type, //REPLY(답장 편지), TARGET(타겟 편지), PUBLIC(퍼블릭 편지)
-        Long sourceLetterId //답장 편지의 경우 원본 편지 id
+        Long sourceLetterId, //답장 편지의 경우 원본 편지 id
+        DeleteMapLettersRequestDTO.LetterType deleteType //삭제 타입
 ) {
-    public static FindMapLetterResponseDTO from(FindSentMapLetter projection, String targetUserNickname) {
+    public static FindMapLetterResponseDTO from(FindSentMapLetter projection, String targetUserNickname,
+                                                LetterType deleteType) {
         return FindMapLetterResponseDTO.builder()
                 .letterId(projection.getLetterId())
                 .title(projection.getTitle())
@@ -25,6 +32,7 @@ public record FindMapLetterResponseDTO(
                 .createdAt(projection.getCreatedAt())
                 .type(projection.getType())
                 .sourceLetterId(projection.getSourceLetterId())
+                .deleteType(deleteType)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/FindReceivedMapLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/FindReceivedMapLetterResponseDTO.java
@@ -19,7 +19,8 @@ public record FindReceivedMapLetterResponseDTO(
         Long sourceLetterId,
         String senderNickname, //타겟편지에서 누가 나한테 보냈는지
         String senderProfileImg, //타겟편지에서 보낸 사람의 프로필 이미지
-        DeleteMapLettersRequestDTO.LetterType deleteType //삭제 타입
+        DeleteMapLettersRequestDTO.LetterType deleteType, //삭제 타입
+        boolean isRead //한 번이라도 읽었는지
 ) {
     public static FindReceivedMapLetterResponseDTO from(FindReceivedMapLetterDTO letterDTO, String senderNickname,
                                                         String senderProfileImg,
@@ -37,6 +38,7 @@ public record FindReceivedMapLetterResponseDTO(
                 .senderNickname(senderNickname)
                 .senderProfileImg(senderProfileImg)
                 .deleteType(deleteType)
+                .isRead(letterDTO.getIsRead() == 1)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/FindReceivedMapLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/FindReceivedMapLetterResponseDTO.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import postman.bottler.mapletter.application.dto.FindReceivedMapLetterDTO;
+import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
 
 @Builder
 public record FindReceivedMapLetterResponseDTO(
@@ -17,10 +18,12 @@ public record FindReceivedMapLetterResponseDTO(
         String type, //reply, target
         Long sourceLetterId,
         String senderNickname, //타겟편지에서 누가 나한테 보냈는지
-        String senderProfileImg //타겟편지에서 보낸 사람의 프로필 이미지
+        String senderProfileImg, //타겟편지에서 보낸 사람의 프로필 이미지
+        DeleteMapLettersRequestDTO.LetterType deleteType //삭제 타입
 ) {
     public static FindReceivedMapLetterResponseDTO from(FindReceivedMapLetterDTO letterDTO, String senderNickname,
-                                                        String senderProfileImg) {
+                                                        String senderProfileImg,
+                                                        DeleteMapLettersRequestDTO.LetterType deleteType) {
         return FindReceivedMapLetterResponseDTO.builder()
                 .letterId(letterDTO.getLetterId())
                 .title(letterDTO.getTitle())
@@ -33,6 +36,7 @@ public record FindReceivedMapLetterResponseDTO(
                 .sourceLetterId(letterDTO.getSourceLetterId())
                 .senderNickname(senderNickname)
                 .senderProfileImg(senderProfileImg)
+                .deleteType(deleteType)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/repository/MapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/MapLetterRepository.java
@@ -38,4 +38,6 @@ public interface MapLetterRepository {
     List<MapLetterAndDistance> guestFindLettersByUserLocation(BigDecimal latitude, BigDecimal longitude);
 
     List<MapLetter> findAllByIds(List<Long> ids);
+
+    void updateRead(MapLetter mapLetter);
 }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -97,7 +97,7 @@ public class MapLetterService {
         mapLetter.validateFindOneMapLetter(VIEW_DISTANCE, distance);
         mapLetter.validateAccess(userId);
 
-        if (mapLetter.getTargetUserId()!=null && mapLetter.getTargetUserId().equals(userId)) {
+        if (mapLetter.isTargetUser(userId)) {
             mapLetterRepository.updateRead(mapLetter);
         }
 

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -86,7 +86,7 @@ public class MapLetterService {
         return save;
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public OneLetterResponseDTO findOneMapLetter(Long letterId, Long userId, BigDecimal latitude,
                                                  BigDecimal longitude) {
         MapLetter mapLetter = mapLetterRepository.findById(letterId);
@@ -96,6 +96,10 @@ public class MapLetterService {
 
         mapLetter.validateFindOneMapLetter(VIEW_DISTANCE, distance);
         mapLetter.validateAccess(userId);
+
+        if (mapLetter.getTargetUserId()!=null && mapLetter.getTargetUserId().equals(userId)) {
+            mapLetterRepository.updateRead(mapLetter);
+        }
 
         String profileImg = userService.getProfileImageUrlById(mapLetter.getCreateUserId());
         return OneLetterResponseDTO.from(mapLetter, profileImg, mapLetter.getCreateUserId() == userId,

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -467,16 +467,19 @@ public class MapLetterService {
     @Transactional
     public void deleteMapLetters(DeleteMapLettersRequestDTO letters, Long userId) {
         for (LetterInfo letter : letters.letters()) {
-            if (letter.letterType() == LetterType.MAP) {
-                MapLetter findMapLetter = mapLetterRepository.findById(letter.letterId());
-                findMapLetter.validDeleteMapLetter(userId);
-                mapLetterRepository.softDelete(letter.letterId());
-            } else if (letter.letterType() == LetterType.REPLY) {
-                ReplyMapLetter replyMapLetter = replyMapLetterRepository.findById(letter.letterId());
-                replyMapLetter.validDeleteReplyMapLetter(userId);
-                replyMapLetterRepository.softDelete(letter.letterId());
+            switch (letter.letterType()){
+                case MAP:
+                    MapLetter findMapLetter = mapLetterRepository.findById(letter.letterId());
+                    findMapLetter.validDeleteMapLetter(userId);
+                    mapLetterRepository.softDelete(letter.letterId());
+                    break;
+                case REPLY:
+                    ReplyMapLetter replyMapLetter = replyMapLetterRepository.findById(letter.letterId());
+                    replyMapLetter.validDeleteReplyMapLetter(userId);
+                    replyMapLetterRepository.softDelete(letter.letterId());
 
-                deleteRecentReply(letter.letterId(), replyMapLetter.getLabel(), replyMapLetter.getSourceLetterId());
+                    deleteRecentReply(letter.letterId(), replyMapLetter.getLabel(), replyMapLetter.getSourceLetterId());
+                    break;
             }
         }
     }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -132,7 +132,8 @@ public class MapLetterService {
             targetUserNickname = userService.getNicknameById(findSentMapLetter.getTargetUser());
         }
 
-        return FindMapLetterResponseDTO.from(findSentMapLetter, targetUserNickname);
+        return FindMapLetterResponseDTO.from(findSentMapLetter, targetUserNickname,
+                findSentMapLetter.getType().equals("REPLY") ? LetterType.REPLY : LetterType.MAP);
     }
 
     @Transactional(readOnly = true)
@@ -156,7 +157,7 @@ public class MapLetterService {
                 senderProfileImg = userService.getProfileImageUrlById(letter.getSenderId());
             }
 
-            return FindReceivedMapLetterResponseDTO.from(letter, senderNickname, senderProfileImg);
+            return FindReceivedMapLetterResponseDTO.from(letter, senderNickname, senderProfileImg, LetterType.MAP);
         });
     }
 
@@ -311,7 +312,7 @@ public class MapLetterService {
             MapLetter sourceLetter = mapLetterRepository.findById(replyMapLetter.getSourceLetterId());
             String title = "Re: " + sourceLetter.getTitle();
 
-            return FindAllSentReplyMapLetterResponseDTO.from(replyMapLetter, title);
+            return FindAllSentReplyMapLetterResponseDTO.from(replyMapLetter, title, LetterType.REPLY);
         });
     }
 
@@ -328,7 +329,7 @@ public class MapLetterService {
             if (mapLetter.getType() == MapLetterType.PRIVATE) {
                 targetUserNickname = userService.getNicknameById(mapLetter.getTargetUserId());
             }
-            return FindAllSentMapLetterResponseDTO.from(mapLetter, targetUserNickname);
+            return FindAllSentMapLetterResponseDTO.from(mapLetter, targetUserNickname, LetterType.MAP);
         });
     }
 
@@ -346,7 +347,7 @@ public class MapLetterService {
         return letters.map(replyMapLetter -> {
             MapLetter sourceLetter = mapLetterRepository.findById(replyMapLetter.getSourceLetterId());
             String title = "Re: " + sourceLetter.getTitle();
-            return FindAllReceivedReplyLetterResponseDTO.from(replyMapLetter, title);
+            return FindAllReceivedReplyLetterResponseDTO.from(replyMapLetter, title, LetterType.MAP);
         });
     }
 
@@ -360,7 +361,7 @@ public class MapLetterService {
         return letters.map(letter -> {
             String sendUserNickname = userService.getNicknameById(letter.getCreateUserId());
             String sendUserProfileImg = userService.getProfileImageUrlById(letter.getCreateUserId());
-            return FindAllReceivedLetterResponseDTO.from(letter, sendUserNickname, sendUserProfileImg);
+            return FindAllReceivedLetterResponseDTO.from(letter, sendUserNickname, sendUserProfileImg, LetterType.MAP);
         });
     }
 

--- a/src/main/java/postman/bottler/mapletter/domain/MapLetter.java
+++ b/src/main/java/postman/bottler/mapletter/domain/MapLetter.java
@@ -35,6 +35,7 @@ public class MapLetter {
     private LocalDateTime updatedAt;
     private boolean isDeleted;
     private boolean isBlocked;
+    private boolean isRead;
 
     public static MapLetter createPublicMapLetter(CreatePublicMapLetterRequestDTO createPublicMapLetterRequestDTO,
                                                   Long userId) {
@@ -52,6 +53,7 @@ public class MapLetter {
                 .updatedAt(LocalDateTime.now())
                 .isDeleted(false)
                 .isBlocked(false)
+                .isRead(false)
                 .description(createPublicMapLetterRequestDTO.description())
                 .build();
     }
@@ -73,6 +75,7 @@ public class MapLetter {
                 .updatedAt(LocalDateTime.now())
                 .isDeleted(false)
                 .isBlocked(false)
+                .isRead(false)
                 .description(createTargetMapLetterRequestDTO.description())
                 .build();
     }
@@ -133,5 +136,4 @@ public class MapLetter {
             throw new CommonForbiddenException("해당 편지에 접근할 수 없습니다.");
         }
     }
-
 }

--- a/src/main/java/postman/bottler/mapletter/domain/MapLetter.java
+++ b/src/main/java/postman/bottler/mapletter/domain/MapLetter.java
@@ -136,4 +136,8 @@ public class MapLetter {
             throw new CommonForbiddenException("해당 편지에 접근할 수 없습니다.");
         }
     }
+
+    public boolean isTargetUser(Long userId) {
+        return this.targetUserId != null && this.targetUserId.equals(userId);
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/exception/MapLetterExceptionHandler.java
+++ b/src/main/java/postman/bottler/mapletter/exception/MapLetterExceptionHandler.java
@@ -111,6 +111,7 @@ public class MapLetterExceptionHandler {
     }
 
     @ExceptionHandler(TypeNotFoundException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<?> handleTypeNotFoundException(TypeNotFoundException e) {
         log.error(e.getMessage());
         return ApiResponse.onFailure(ErrorStatus.TYPE_NOT_FOUND.getCode(), e.getMessage(), null);

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterJpaRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterJpaRepository.java
@@ -91,7 +91,7 @@ public interface MapLetterJpaRepository extends JpaRepository<MapLetterEntity, L
 
     @Query(value = "SELECT m.map_letter_id AS letterId, m.title AS title, m.description AS description, "
             + "m.latitude as latitude, m.longitude as longitude, " +
-            "m.label AS label, NULL AS sourceLetterId, 'TARGET' AS type, m.created_at AS createdAt, m.create_user_id as senderId  "
+            "m.label AS label, NULL AS sourceLetterId, 'TARGET' AS type, m.created_at AS createdAt, m.create_user_id as senderId, m.is_read as isRead  "
             +
             "FROM map_letter m " +
             "WHERE m.target_user_id = :userId AND m.is_deleted = false AND m.is_blocked = false " +
@@ -99,7 +99,7 @@ public interface MapLetterJpaRepository extends JpaRepository<MapLetterEntity, L
             "SELECT r.reply_letter_id AS letterId, "
             + "CONCAT('Re: ', (SELECT ml.title FROM map_letter ml WHERE ml.map_letter_id = r.source_letter_id)) AS title, "
             + "NULL AS description, NULL AS latitude, NULL AS longitude, "
-            + "r.label AS label, r.source_letter_id AS sourceLetterId, 'REPLY' AS type, r.created_at AS createdAt, r.create_user_id as senderId "
+            + "r.label AS label, r.source_letter_id AS sourceLetterId, 'REPLY' AS type, r.created_at AS createdAt, r.create_user_id as senderId, false as isRead "
             +
             "FROM reply_map_letter r " +
             "WHERE r.create_user_id = :userId AND r.is_deleted = false AND r.is_blocked = false " +

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
@@ -106,4 +106,11 @@ public class MapLetterRepositoryImpl implements MapLetterRepository {
                 .map(MapLetterEntity::toDomain)
                 .toList();
     }
+
+    @Override
+    public void updateRead(MapLetter mapLetter) {
+        MapLetterEntity mapLetterEntity = mapLetterJpaRepository.findById(mapLetter.getId())
+                        .orElseThrow(()->new MapLetterNotFoundException("해당 편지를 찾을 수 없습니다."));
+        mapLetterEntity.updateRead();
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/entity/MapLetterEntity.java
+++ b/src/main/java/postman/bottler/mapletter/infra/entity/MapLetterEntity.java
@@ -59,12 +59,13 @@ public class MapLetterEntity {
     private LocalDateTime updatedAt;
     private boolean isDeleted;
     private boolean isBlocked;
+    private boolean isRead;
 
     @Builder
     public MapLetterEntity(String title, String content, BigDecimal latitude, BigDecimal longitude, String font,
                            String paper, String label, MapLetterType type, Long targetUserId, Long createUserId,
                            LocalDateTime createdAt, LocalDateTime updatedAt, boolean isDeleted, boolean isBlocked,
-                           String description) {
+                           String description, boolean isRead) {
         this.title = title;
         this.content = content;
         this.latitude = latitude;
@@ -80,6 +81,7 @@ public class MapLetterEntity {
         this.isDeleted = isDeleted;
         this.isBlocked = isBlocked;
         this.description = description;
+        this.isRead = isRead;
     }
 
     public static MapLetterEntity from(MapLetter mapLetter) {
@@ -99,6 +101,7 @@ public class MapLetterEntity {
                 .isDeleted(mapLetter.isDeleted())
                 .isBlocked(mapLetter.isBlocked())
                 .description(mapLetter.getDescription())
+                .isRead(mapLetter.isRead())
                 .build();
     }
 
@@ -120,10 +123,15 @@ public class MapLetterEntity {
                 .isDeleted(mapLetterEntity.isDeleted)
                 .isBlocked(mapLetterEntity.isBlocked)
                 .description(mapLetterEntity.description)
+                .isRead(mapLetterEntity.isRead)
                 .build();
     }
 
     public void updateDelete(boolean isDeleted) {
         this.isDeleted = isDeleted;
+    }
+
+    public void updateRead() {
+        this.isRead = true;
     }
 }

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -22,6 +22,7 @@ import postman.bottler.mapletter.application.dto.request.CreateReplyMapLetterReq
 import postman.bottler.mapletter.application.dto.request.CreateTargetMapLetterRequestDTO;
 import postman.bottler.mapletter.application.dto.request.DeleteArchivedLettersRequestDTO;
 import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
+import postman.bottler.mapletter.application.dto.request.DeleteMapLettersV1RequestDTO;
 import postman.bottler.mapletter.application.dto.response.CheckReplyMapLetterResponseDTO;
 import postman.bottler.mapletter.application.dto.response.FindAllArchiveLetters;
 import postman.bottler.mapletter.application.dto.response.FindAllReceivedLetterResponseDTO;
@@ -117,8 +118,8 @@ public class MapLetterController {
     }
 
     @DeleteMapping
-    @Operation(summary = "편지 삭제", description = "로그인 필수. 리스트 형태로 1개 ~ n개까지 삭제 가능")
-    public ApiResponse<?> deleteMapLetter(@RequestBody DeleteMapLettersRequestDTO letters,
+    @Operation(summary = "편지 삭제", description = "로그인 필수. 리스트 형태로 1개 ~ n개까지 삭제 가능. 3차 스프린트 기간 삭제 예정")
+    public ApiResponse<?> deleteMapLetter(@RequestBody DeleteMapLettersV1RequestDTO letters,
                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
         mapLetterService.deleteMapLetter(letters.letterIds(), userId);
@@ -219,8 +220,8 @@ public class MapLetterController {
     }
 
     @DeleteMapping("/reply")
-    @Operation(summary = "답장 편지 삭제", description = "로그인 필수. 답장 편지 삭제. 리스트 형태")
-    public ApiResponse<?> deleteReplyMapLetter(@RequestBody DeleteMapLettersRequestDTO letters,
+    @Operation(summary = "답장 편지 삭제", description = "로그인 필수. 답장 편지 삭제. 리스트 형태. 3차 스프린트 기간 삭제 예정")
+    public ApiResponse<?> deleteReplyMapLetter(@RequestBody DeleteMapLettersV1RequestDTO letters,
                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
         mapLetterService.deleteReplyMapLetter(letters.letterIds(), userId);
@@ -288,5 +289,14 @@ public class MapLetterController {
                             MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedLetter(page, size, userId)));
             default -> throw new TypeNotFoundException("올바르지 못한 타입입니다.");
         };
+    }
+
+    @DeleteMapping("/v2")
+    @Operation(summary = "편지 삭제", description = "로그인 필수. 지도편지, 답장편지 구분해서 보내주세요. 리스트 형태로 1개 ~ n개까지 삭제 가능")
+    public ApiResponse<?> deleteMapLetter(@RequestBody DeleteMapLettersRequestDTO deleteLetters,
+                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        mapLetterService.deleteMapLetters(deleteLetters, userId);
+        return ApiResponse.onDeleteSuccess(deleteLetters);
     }
 }

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -248,47 +248,6 @@ public class MapLetterController {
         return ApiResponse.onDeleteSuccess(letters);
     }
 
-//    @GetMapping("/sent/reply")
-//    @Operation(summary = "보낸 답장 편지 조회", description = "보낸 편지 조회에서 답장 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
-//    public ApiResponse<MapLetterPageResponseDTO<FindAllSentReplyMapLetterResponseDTO>> findAllSentReplyMapLetter(
-//            @RequestParam(defaultValue = "1") int page,
-//            @RequestParam(defaultValue = "9") int size,
-//            @AuthenticationPrincipal CustomUserDetails userDetails) {
-//        Long userId = userDetails.getUserId();
-//        return ApiResponse.onSuccess(
-//                MapLetterPageResponseDTO.from(mapLetterService.findAllSentReplyMapLetter(page, size, userId)));
-//    }
-
-//    @GetMapping("/sent/letter")
-//    @Operation(summary = "보낸 지도 편지 조회", description = "보낸 편지 조회에서 지도 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
-//    public ApiResponse<MapLetterPageResponseDTO<FindAllSentMapLetterResponseDTO>> findAllSentMapLetter(
-//            @RequestParam(defaultValue = "1") int page,
-//            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
-//        Long userId = userDetails.getUserId();
-//        return ApiResponse.onSuccess(
-//                MapLetterPageResponseDTO.from(mapLetterService.findAllSentMapLetter(page, size, userId)));
-//    }
-
-//    @GetMapping("/received/reply")
-//    @Operation(summary = "받은 답장 편지 조회", description = "받은 편지 조회에서 답장 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
-//    public ApiResponse<MapLetterPageResponseDTO<FindAllReceivedReplyLetterResponseDTO>> findAllReceivedReplyMapLetter(
-//            @RequestParam(defaultValue = "1") int page,
-//            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
-//        Long userId = userDetails.getUserId();
-//        return ApiResponse.onSuccess(
-//                MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedReplyLetter(page, size, userId)));
-//    }
-
-//    @GetMapping("/received/letter")
-//    @Operation(summary = "받은 타겟 편지 조회", description = "받은 편지 조회에서 타겟 편지만 보고싶을 경우 사용하는 api. 페이징 처리 때문에 따르 api 생성")
-//    public ApiResponse<MapLetterPageResponseDTO<FindAllReceivedLetterResponseDTO>> findAllReceivedMapLetter(
-//            @RequestParam(defaultValue = "1") int page,
-//            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
-//        Long userId = userDetails.getUserId();
-//        return ApiResponse.onSuccess(
-//                MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedLetter(page, size, userId)));
-//    }
-
     @GetMapping("/guest")
     @Operation(summary = "로그인 하지 않은 유저 주변 편지 조회", description = "로그인 하지 않은 유저의 반경 500m 내 퍼블릭 편지 조회")
     public ApiResponse<List<FindNearbyLettersResponseDTO>> guestFindNearbyMapLetters(@RequestParam String latitude,

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -125,27 +125,6 @@ public class MapLetterController {
         return ApiResponse.onDeleteSuccess(letters);
     }
 
-//    @GetMapping("/sent")
-//    @Operation(summary = "보낸 편지 전체 조회", description = "로그인 필수. 내가 보낸 편지, 답장 전체 조회. 페이징 처리(1페이지부터). ")
-//    public ApiResponse<MapLetterPageResponseDTO<FindMapLetterResponseDTO>> findSentMapLetters(
-//            @RequestParam(defaultValue = "1") int page,
-//            @RequestParam(defaultValue = "9") int size, @AuthenticationPrincipal CustomUserDetails userDetails) {
-//        Long userId = userDetails.getUserId();
-//        return ApiResponse.onSuccess(
-//                MapLetterPageResponseDTO.from(mapLetterService.findSentMapLetters(page, size, userId)));
-//    }
-
-//    @GetMapping("/received")
-//    @Operation(summary = "받은 편지 전체 조회", description = "로그인 필수. 내가 타겟인 편지, 나에게 온 답장 전체 조회. 페이징 처리(1페이지부터)")
-//    public ApiResponse<MapLetterPageResponseDTO<FindReceivedMapLetterResponseDTO>> findReceivedMapLetters(
-//            @RequestParam(defaultValue = "1") int page,
-//            @RequestParam(defaultValue = "9") int size,
-//            @AuthenticationPrincipal CustomUserDetails userDetails) {
-//        Long userId = userDetails.getUserId();
-//        return ApiResponse.onSuccess(
-//                MapLetterPageResponseDTO.from(mapLetterService.findReceivedMapLetters(page, size, userId)));
-//    }
-
     @GetMapping
     @Operation(summary = "주변 편지 조회", description = "로그인 필수. 반경 500m 내 퍼블릭 편지, 나에게 타겟으로 온 편지 조회")
     public ApiResponse<List<FindNearbyLettersResponseDTO>> findNearbyMapLetters(@RequestParam String latitude,

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -117,15 +117,6 @@ public class MapLetterController {
         return ApiResponse.onSuccess(mapLetterService.findOneMapLetter(letterId, userId, lat, lon));
     }
 
-    @DeleteMapping
-    @Operation(summary = "편지 삭제", description = "로그인 필수. 리스트 형태로 1개 ~ n개까지 삭제 가능. 3차 스프린트 기간 삭제 예정")
-    public ApiResponse<?> deleteMapLetter(@RequestBody DeleteMapLettersV1RequestDTO letters,
-                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        mapLetterService.deleteMapLetter(letters.letterIds(), userId);
-        return ApiResponse.onDeleteSuccess(letters);
-    }
-
     @GetMapping
     @Operation(summary = "주변 편지 조회", description = "로그인 필수. 반경 500m 내 퍼블릭 편지, 나에게 타겟으로 온 편지 조회")
     public ApiResponse<List<FindNearbyLettersResponseDTO>> findNearbyMapLetters(@RequestParam String latitude,
@@ -219,15 +210,6 @@ public class MapLetterController {
         return ApiResponse.onSuccess(mapLetterService.findArchiveOneLetter(letterId, userId));
     }
 
-    @DeleteMapping("/reply")
-    @Operation(summary = "답장 편지 삭제", description = "로그인 필수. 답장 편지 삭제. 리스트 형태. 3차 스프린트 기간 삭제 예정")
-    public ApiResponse<?> deleteReplyMapLetter(@RequestBody DeleteMapLettersV1RequestDTO letters,
-                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        mapLetterService.deleteReplyMapLetter(letters.letterIds(), userId);
-        return ApiResponse.onDeleteSuccess(letters);
-    }
-
     @GetMapping("/guest")
     @Operation(summary = "로그인 하지 않은 유저 주변 편지 조회", description = "로그인 하지 않은 유저의 반경 500m 내 퍼블릭 편지 조회")
     public ApiResponse<List<FindNearbyLettersResponseDTO>> guestFindNearbyMapLetters(@RequestParam String latitude,
@@ -289,6 +271,24 @@ public class MapLetterController {
                             MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedLetter(page, size, userId)));
             default -> throw new TypeNotFoundException("올바르지 못한 타입입니다.");
         };
+    }
+
+    @DeleteMapping
+    @Operation(summary = "편지 삭제", description = "로그인 필수. 리스트 형태로 1개 ~ n개까지 삭제 가능. 3차 스프린트 기간 삭제 예정")
+    public ApiResponse<?> deleteMapLetter(@RequestBody DeleteMapLettersV1RequestDTO letters,
+                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        mapLetterService.deleteMapLetter(letters.letterIds(), userId);
+        return ApiResponse.onDeleteSuccess(letters);
+    }
+
+    @DeleteMapping("/reply")
+    @Operation(summary = "답장 편지 삭제", description = "로그인 필수. 답장 편지 삭제. 리스트 형태. 3차 스프린트 기간 삭제 예정")
+    public ApiResponse<?> deleteReplyMapLetter(@RequestBody DeleteMapLettersV1RequestDTO letters,
+                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        mapLetterService.deleteReplyMapLetter(letters.letterIds(), userId);
+        return ApiResponse.onDeleteSuccess(letters);
     }
 
     @DeleteMapping("/v2")


### PR DESCRIPTION
## 📢 기능 설명 
### 1. 지도편지/답장편지 삭제 api 합치기(아이디, 타입)
```
{
  "letters": [
    {
      "letterType": "REPLY", //REPLY, MAP
      "letterId": 1
    },
    {
      "letterType": "MAP",
      "letterId": 2
    }
  ]
}
```
- 이렇게 타입하고 id 같이 list로 받아서 삭제하도록 했습니다.
- 저번에 말 한 것 처럼 기존 api도 살리고 추가 api도 살렸어요! 프론트가 변경 완료하면 다음 스프린트 기간에 삭제하면 될듯 합니다~ 이렇게 하는게 맞겠죠???ㅎ
<br>

### 2. 편지 내려줄 때 편지 타입도 같이 내려주기
```
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "content": [
            {
                "letterId": 13,
                "title": "제목11",
                "description": "종로구 파리바게트 앞",
                "label": "www.aaa.com",
                "targetUserNickname": null,
                "createdAt": "2025-01-13T22:28:21.88139",
                "type": "PUBLIC",
                "sourceLetterId": null,
                "deleteType": "MAP"
            },
            {
                "letterId": 2,
                "title": "Re: 제목차",
                "description": null,
                "label": "www.aaa.com",
                "targetUserNickname": null,
                "createdAt": "2025-01-13T21:34:41.257708",
                "type": "REPLY",
                "sourceLetterId": 5,
                "deleteType": "REPLY"
            }
        ],
        "page": 1,
        "size": 9,
        "totalElements": 2,
        "totalPages": 1
    }
}
```
위에 삭제를 위해서 타입이 MAP인지 REPLY인지 같이 주도록 변경했어요.
<br>

### 3. 받은 편지 -> 보관함에서 확인은 할 수 있되, 지도에서 한 번이라도 조회 한 경우에만 볼 수 있도록
```
{
    "isSuccess": true,
    "code": "COMMON200",
    "message": "성공입니다.",
    "result": {
        "content": [
            {
                "letterId": 15,
                "title": "제목입ㄴ디ㅏㅇ",
                "description": "민락 거기 학교끝나고 가던 곳",
                "latitude": 37.7423000,
                "longitude": 127.0910820,
                "label": "www.aaa.com",
                "createdAt": "2025-01-14T15:01:26.370947",
                "type": "TARGET",
                "sourceLetterId": null,
                "senderNickname": "가현현",
                "senderProfileImg": "https://img.bottler.store/profile2.svg",
                "deleteType": "MAP",
                "isRead": false
            },
            {
                "letterId": 14,
                "title": "제목입ㄴ디ㅏㅇ",
                "description": "민락 거기 학교끝나고 가던 곳",
                "latitude": 37.7423000,
                "longitude": 127.0910820,
                "label": "www.aaa.com",
                "createdAt": "2025-01-14T15:01:23.814463",
                "type": "TARGET",
                "sourceLetterId": null,
                "senderNickname": "가현현",
                "senderProfileImg": "https://img.bottler.store/profile2.svg",
                "deleteType": "MAP",
                "isRead": false
            },
            {
                "letterId": 2,
                "title": "Re: 제목차",
                "description": null,
                "latitude": null,
                "longitude": null,
                "label": "www.aaa.com",
                "createdAt": "2025-01-13T21:34:41.257708",
                "type": "REPLY",
                "sourceLetterId": 5,
                "senderNickname": null,
                "senderProfileImg": null,
                "deleteType": "MAP",
                "isRead": false
            }
        ],
        "page": 1,
        "size": 9,
        "totalElements": 3,
        "totalPages": 1
    }
}

```
> `받은 편지 전체 조회`, `받은 타겟 편지 전체 조회`시 `isRead`를 같이 내려줌
> isRead를 보고 false면 오류 창, true면 편지 상세 조회 api로 보내주기

- map_letter 테이블에 로그인 한 유저가 지도에서 내가 타겟인 편지를 읽었는지 확인하는 `is_read`가 추가되었어요! 

<br>

## 연결된 issue
close #251 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
