### PR TITLE
Feature/#259 : 읽지 않은 알림 개수 조회 기능 추가

### DIFF
--- a/src/main/java/postman/bottler/notification/application/dto/response/UnreadNotificationResponseDTO.java
+++ b/src/main/java/postman/bottler/notification/application/dto/response/UnreadNotificationResponseDTO.java
@@ -1,0 +1,6 @@
+package postman.bottler.notification.application.dto.response;
+
+public record UnreadNotificationResponseDTO(
+        long count
+) {
+}

--- a/src/main/java/postman/bottler/notification/application/service/NotificationService.java
+++ b/src/main/java/postman/bottler/notification/application/service/NotificationService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import postman.bottler.notification.application.PushNotificationProvider;
 import postman.bottler.notification.application.dto.request.RecommendNotificationRequestDTO;
+import postman.bottler.notification.application.dto.response.UnreadNotificationResponseDTO;
 import postman.bottler.notification.application.dto.response.NotificationResponseDTO;
 import postman.bottler.notification.application.repository.NotificationRepository;
 import postman.bottler.notification.application.repository.SubscriptionRepository;
@@ -34,6 +35,12 @@ public class NotificationService {
             pushNotificationProvider.pushAll(pushMessages);
         }
         return result;
+    }
+
+    @Transactional(readOnly = true)
+    public UnreadNotificationResponseDTO getUnreadNotificationCount(Long userId) {
+        Notifications notifications = notificationRepository.findByReceiver(userId);
+        return new UnreadNotificationResponseDTO(notifications.getUnreadCount());
     }
 
     @Transactional

--- a/src/main/java/postman/bottler/notification/domain/Notifications.java
+++ b/src/main/java/postman/bottler/notification/domain/Notifications.java
@@ -30,4 +30,10 @@ public class Notifications {
         }
         return new Notifications(changed);
     }
+
+    public long getUnreadCount() {
+        return notifications.stream()
+                .filter(n -> !n.getIsRead())
+                .count();
+    }
 }

--- a/src/main/java/postman/bottler/notification/presentation/NotificationController.java
+++ b/src/main/java/postman/bottler/notification/presentation/NotificationController.java
@@ -8,12 +8,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import postman.bottler.global.response.ApiResponse;
+import postman.bottler.notification.application.dto.response.UnreadNotificationResponseDTO;
 import postman.bottler.notification.domain.NotificationType;
 import postman.bottler.notification.application.dto.request.NotificationRequestDTO;
 import postman.bottler.notification.application.dto.request.SubscriptionRequestDTO;
@@ -55,6 +57,15 @@ public class NotificationController {
         List<NotificationResponseDTO> userNotifications = notificationService.getUserNotifications(
                 customUserDetails.getUserId());
         return ApiResponse.onSuccess(userNotifications);
+    }
+
+    @Operation(summary = "읽지 않은 알림 개수 조회", description = "사용자의 안읽은 알림 개수를 조회합니다.")
+    @GetMapping("/unread")
+    public ApiResponse<UnreadNotificationResponseDTO> getUnreadCount(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        UnreadNotificationResponseDTO unreadNotificationCount = notificationService.getUnreadNotificationCount(
+                customUserDetails.getUserId());
+        return ApiResponse.onSuccess(unreadNotificationCount);
     }
 
     @Operation(summary = "알림 허용", description = "사용자의 기기 토큰을 등록합니다.")

--- a/src/test/java/postman/bottler/notification/application/NotificationServiceTest.java
+++ b/src/test/java/postman/bottler/notification/application/NotificationServiceTest.java
@@ -15,8 +15,12 @@ import static postman.bottler.notification.domain.NotificationType.TARGET_LETTER
 import static postman.bottler.notification.domain.NotificationType.WARNING;
 import static postman.bottler.notification.domain.NotificationType.from;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import postman.bottler.notification.application.dto.request.NotificationRequestDTO;
 import postman.bottler.notification.application.dto.request.RecommendNotificationRequestDTO;
+import postman.bottler.notification.application.dto.response.UnreadNotificationResponseDTO;
 import postman.bottler.notification.application.dto.response.NotificationResponseDTO;
 import postman.bottler.notification.application.repository.NotificationRepository;
 import postman.bottler.notification.application.repository.SubscriptionRepository;
@@ -268,5 +273,21 @@ public class NotificationServiceTest {
             verify(notificationRepository, times(2)).save(any());
             verify(pushNotificationProvider, times(1)).pushAll(any());
         }
+    }
+
+    @DisplayName("사용자의 읽지 않은 알림의 개수를 반환한다.")
+    @Test
+    void getUnreadNotificationCount() {
+        // given
+        given(notificationRepository.findByReceiver(any()))
+                .willReturn(Notifications.from(Arrays.asList(
+                        Notification.of(UUID.randomUUID(), WARNING, 1L, null, LocalDateTime.now(), true, null),
+                        Notification.of(UUID.randomUUID(), BAN, 1L, null, LocalDateTime.now(), false, null))));
+
+        // when
+        UnreadNotificationResponseDTO result = notificationService.getUnreadNotificationCount(1L);
+
+        // then
+        assertThat(result.count()).isEqualTo(1L);
     }
 }

--- a/src/test/java/postman/bottler/notification/domain/NotificationsTest.java
+++ b/src/test/java/postman/bottler/notification/domain/NotificationsTest.java
@@ -5,8 +5,10 @@ import static postman.bottler.notification.domain.NotificationType.WARNING;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -54,5 +56,21 @@ class NotificationsTest {
         assertThat(markAsRead.getNotifications()).hasSize(2)
                 .extracting("isRead")
                 .contains(true);
+    }
+
+    @DisplayName("읽지 않은 알림의 개수를 조회한다.")
+    @Test
+    void getUnreadCount() {
+        // given
+        Notification n1 = Notification.of(UUID.randomUUID(), WARNING, 1L, null, LocalDateTime.now(), false, null);
+        Notification n2 = Notification.of(UUID.randomUUID(), WARNING, 1L, null, LocalDateTime.now(), false, null);
+        Notification n3 = Notification.of(UUID.randomUUID(), WARNING, 1L, null, LocalDateTime.now(), true, null);
+        Notifications notifications = Notifications.from(Arrays.asList(n1, n2, n3));
+
+        // when
+        long count = notifications.getUnreadCount();
+
+        // then
+        assertThat(count).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명 

알림 중, 읽지 않은 알림의 개수를 조회하는 기능을 추가했습니다.

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #259 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
