### PR TITLE
Fix / 편지에 대한 답장 알림시 답장된 편지 Id가 아닌 편지 Id가 제공되는 문제 수정

### DIFF
--- a/src/main/java/postman/bottler/letter/application/service/ReplyLetterService.java
+++ b/src/main/java/postman/bottler/letter/application/service/ReplyLetterService.java
@@ -134,7 +134,7 @@ public class ReplyLetterService {
         notificationService.sendNotification(
                 KEYWORD_REPLY,
                 replyLetter.getReceiverId(),
-                replyLetter.getLetterId(),
+                replyLetter.getId(),
                 replyLetter.getLabel()
         );
     }


### PR DESCRIPTION
## 📢 기능 설명 
편지에 대한 답장 알림시 답장된 편지 Id가 아닌 편지 Id가 제공되는 문제 수정<br>

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #266 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
