### PR TITLE
Fix/#279 3차 스프린트 기간 지도편지 수정

### DIFF
--- a/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteArchivedLettersRequestDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteArchivedLettersRequestDTO.java
@@ -3,6 +3,6 @@ package postman.bottler.mapletter.application.dto.request;
 import java.util.List;
 
 public record DeleteArchivedLettersRequestDTO(
-        List<Long> archiveIds
+        List<Long> letterIds
 ) {
 }

--- a/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteArchivedLettersRequestDTOV1.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteArchivedLettersRequestDTOV1.java
@@ -1,0 +1,8 @@
+package postman.bottler.mapletter.application.dto.request;
+
+import java.util.List;
+
+public record DeleteArchivedLettersRequestDTOV1( //삭제 예정
+        List<Long> archiveIds
+) {
+}

--- a/src/main/java/postman/bottler/mapletter/application/dto/response/OneLetterResponseDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/response/OneLetterResponseDTO.java
@@ -17,7 +17,8 @@ public record OneLetterResponseDTO(
         LocalDateTime createdAt,
         boolean isOwner,
         boolean isReplied,
-        boolean isArchived
+        boolean isArchived,
+        boolean isTarget
 ) {
     public static OneLetterResponseDTO from(MapLetter mapLetter, String profileImg, boolean isOwner, boolean isReplied,
                                             boolean isArchived) {
@@ -33,6 +34,7 @@ public record OneLetterResponseDTO(
                 .isOwner(isOwner)
                 .isReplied(isReplied)
                 .isArchived(isArchived)
+                .isTarget(mapLetter.getTargetUserId()!=null)
                 .build();
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/repository/MapLetterArchiveRepository.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/MapLetterArchiveRepository.java
@@ -1,5 +1,6 @@
 package postman.bottler.mapletter.application.repository;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -17,4 +18,8 @@ public interface MapLetterArchiveRepository {
     void deleteById(Long letterId);
 
     boolean findByLetterIdAndUserId(Long letterId, Long userId);
+
+    List<MapLetterArchive> findAllById(List<Long> letterIds);
+
+    void deleteAllByIdInBatch(List<Long> letterIds);
 }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -25,6 +25,7 @@ import postman.bottler.mapletter.application.dto.request.CreatePublicMapLetterRe
 import postman.bottler.mapletter.application.dto.request.CreateReplyMapLetterRequestDTO;
 import postman.bottler.mapletter.application.dto.request.CreateTargetMapLetterRequestDTO;
 import postman.bottler.mapletter.application.dto.request.DeleteArchivedLettersRequestDTO;
+import postman.bottler.mapletter.application.dto.request.DeleteArchivedLettersRequestDTOV1;
 import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
 import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO.LetterInfo;
 import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO.LetterType;
@@ -258,6 +259,15 @@ public class MapLetterService {
 
     @Transactional
     public void deleteArchivedLetter(DeleteArchivedLettersRequestDTO deleteArchivedLettersRequestDTO, Long userId) {
+        for (Long archiveId : deleteArchivedLettersRequestDTO.letterIds()) {
+            MapLetterArchive findArchiveInfo = mapLetterArchiveRepository.findById(archiveId);
+            findArchiveInfo.validDeleteArchivedLetter(userId);
+            mapLetterArchiveRepository.deleteById(archiveId);
+        }
+    }
+
+    @Transactional
+    public void deleteArchivedLetter(DeleteArchivedLettersRequestDTOV1 deleteArchivedLettersRequestDTO, Long userId) { //삭제 예정
         for (Long archiveId : deleteArchivedLettersRequestDTO.archiveIds()) {
             MapLetterArchive findArchiveInfo = mapLetterArchiveRepository.findById(archiveId);
             findArchiveInfo.validDeleteArchivedLetter(userId);

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterArchiveRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterArchiveRepositoryImpl.java
@@ -1,5 +1,7 @@
 package postman.bottler.mapletter.infra;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,5 +47,18 @@ public class MapLetterArchiveRepositoryImpl implements MapLetterArchiveRepositor
     public boolean findByLetterIdAndUserId(Long letterId, Long userId) {
         return mapLetterArchiveJpaRepository.findByMapLetterIdAndUserId(letterId, userId).isPresent();
         // 값이 없으면 false
+    }
+
+    @Override
+    public List<MapLetterArchive> findAllById(List<Long> letterIds) {
+        return mapLetterArchiveJpaRepository.findAllById(letterIds)
+                .stream()
+                .map(MapLetterArchiveEntity::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(List<Long> letterIds) {
+        mapLetterArchiveJpaRepository.deleteAllByIdInBatch(letterIds);
     }
 }

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -26,14 +26,8 @@ import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequest
 import postman.bottler.mapletter.application.dto.request.DeleteMapLettersV1RequestDTO;
 import postman.bottler.mapletter.application.dto.response.CheckReplyMapLetterResponseDTO;
 import postman.bottler.mapletter.application.dto.response.FindAllArchiveLetters;
-import postman.bottler.mapletter.application.dto.response.FindAllReceivedLetterResponseDTO;
-import postman.bottler.mapletter.application.dto.response.FindAllReceivedReplyLetterResponseDTO;
 import postman.bottler.mapletter.application.dto.response.FindAllReplyMapLettersResponseDTO;
-import postman.bottler.mapletter.application.dto.response.FindAllSentMapLetterResponseDTO;
-import postman.bottler.mapletter.application.dto.response.FindAllSentReplyMapLetterResponseDTO;
-import postman.bottler.mapletter.application.dto.response.FindMapLetterResponseDTO;
 import postman.bottler.mapletter.application.dto.response.FindNearbyLettersResponseDTO;
-import postman.bottler.mapletter.application.dto.response.FindReceivedMapLetterResponseDTO;
 import postman.bottler.mapletter.application.dto.response.MapLetterPageResponseDTO;
 import postman.bottler.mapletter.application.dto.response.OneLetterResponseDTO;
 import postman.bottler.mapletter.application.dto.response.OneReplyLetterResponseDTO;

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -21,6 +21,7 @@ import postman.bottler.mapletter.application.dto.request.CreatePublicMapLetterRe
 import postman.bottler.mapletter.application.dto.request.CreateReplyMapLetterRequestDTO;
 import postman.bottler.mapletter.application.dto.request.CreateTargetMapLetterRequestDTO;
 import postman.bottler.mapletter.application.dto.request.DeleteArchivedLettersRequestDTO;
+import postman.bottler.mapletter.application.dto.request.DeleteArchivedLettersRequestDTOV1;
 import postman.bottler.mapletter.application.dto.request.DeleteMapLettersRequestDTO;
 import postman.bottler.mapletter.application.dto.request.DeleteMapLettersV1RequestDTO;
 import postman.bottler.mapletter.application.dto.response.CheckReplyMapLetterResponseDTO;
@@ -186,7 +187,16 @@ public class MapLetterController {
     }
 
     @DeleteMapping("/archived")
-    @Operation(summary = "편지 보관 취소(삭제)", description = "로그인 필수. 편지를 보관함에서 삭제한다.(리스트로 1~n개 까지의 편지를 한 번에 삭제 한다.")
+    @Operation(summary = "편지 보관 취소(삭제) 프론트 v2로 변경 후 삭제 할 코드입니다.", description = "로그인 필수. 편지를 보관함에서 삭제한다.(리스트로 1~n개 까지의 편지를 한 번에 삭제 한다.")
+    public ApiResponse<?> archiveLetterV1(@RequestBody DeleteArchivedLettersRequestDTOV1 deleteArchivedLettersRequestDTO
+            , @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        mapLetterService.deleteArchivedLetter(deleteArchivedLettersRequestDTO, userId);
+        return ApiResponse.onDeleteSuccess(deleteArchivedLettersRequestDTO);
+    }
+
+    @DeleteMapping("/archived/v2")
+    @Operation(summary = "편지 보관 취소(삭제) 변경 한 코드입니다.", description = "로그인 필수. 편지를 보관함에서 삭제한다.(리스트로 1~n개 까지의 편지를 한 번에 삭제 한다.")
     public ApiResponse<?> archiveLetter(@RequestBody DeleteArchivedLettersRequestDTO deleteArchivedLettersRequestDTO
             , @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -254,7 +254,7 @@ public class MapLetterController {
     }
 
     @GetMapping("/saved")
-    public ApiResponse<?> savedLetters(@RequestParam String type, @AuthenticationPrincipal CustomUserDetails user,
+    public ApiResponse<?> savedLettersV1(@RequestParam String type, @AuthenticationPrincipal CustomUserDetails user,
                                        @RequestParam(defaultValue = "1") int page,
                                        @RequestParam(defaultValue = "9") int size) {
         Long userId = user.getUserId();
@@ -277,6 +277,36 @@ public class MapLetterController {
                             MapLetterPageResponseDTO.from(
                                     mapLetterService.findAllReceivedReplyLetter(page, size, userId)));
             case "received-target" -> //받은 타겟 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedLetter(page, size, userId)));
+            default -> throw new TypeNotFoundException("올바르지 못한 타입입니다.");
+        };
+    }
+
+    @GetMapping("/saved/v2")
+    public ApiResponse<?> savedLetters(@RequestParam String type, @AuthenticationPrincipal CustomUserDetails user,
+                                       @RequestParam(defaultValue = "1") int page,
+                                       @RequestParam(defaultValue = "9") int size) {
+        Long userId = user.getUserId();
+        return switch (type) {
+            case "sent-all" -> //보낸 편지 전체 조회(지도편지, 답장 편지)
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(mapLetterService.findSentMapLetters(page, size, userId)));
+            case "sent-reply" -> //보낸 답장 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(
+                                    mapLetterService.findAllSentReplyMapLetter(page, size, userId)));
+            case "sent-map" -> //보낸 지도 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(mapLetterService.findAllSentMapLetter(page, size, userId)));
+            case "received-all" -> //받은 편지 전체 조회(타겟 편지, 답장 편지)
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(mapLetterService.findReceivedMapLetters(page, size, userId)));
+            case "received-reply" -> //받은 답장 편지 전체 조회
+                    ApiResponse.onSuccess(
+                            MapLetterPageResponseDTO.from(
+                                    mapLetterService.findAllReceivedReplyLetter(page, size, userId)));
+            case "received-map" -> //받은 타겟 편지 전체 조회
                     ApiResponse.onSuccess(
                             MapLetterPageResponseDTO.from(mapLetterService.findAllReceivedLetter(page, size, userId)));
             default -> throw new TypeNotFoundException("올바르지 못한 타입입니다.");


### PR DESCRIPTION
## 📢 기능 설명 
1. /map/archived : 편지 보관 취소(삭제) - request 'letterIds’로 변경
2. /map/{letterId} : 편지 상세 조회 - 타겟 편지가 맞는지 boolean
3. 마이페이지 편지 조회에서 받은 타겟 편지 전체 조회 파라미터를 received-map으로 변경

까먹을까봐 미리 적어요! 다음 회의 때  2차 스프린트 기간에 수정한 api 프론트 변경 여부 물어보고, 수정 전 코드 삭제할게요!!
<br>

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #279 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
