### PR TITLE
fix: 트랜잭션 문제로 인해 키워드가 일관되지 않게 조회되는 버그 수정

### DIFF
--- a/src/main/java/postman/bottler/keyword/application/repository/LetterKeywordRepository.java
+++ b/src/main/java/postman/bottler/keyword/application/repository/LetterKeywordRepository.java
@@ -12,5 +12,5 @@ public interface LetterKeywordRepository {
 
     void markKeywordsAsDeleted(List<Long> letterIds);
 
-    List<LetterKeyword> getFrequentKeywords(List<Long> letterIds);
+    List<String> getFrequentKeywords(List<Long> letterIds);
 }

--- a/src/main/java/postman/bottler/keyword/infra/LetterKeywordQueryDslRepository.java
+++ b/src/main/java/postman/bottler/keyword/infra/LetterKeywordQueryDslRepository.java
@@ -1,6 +1,5 @@
 package postman.bottler.keyword.infra;
 
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -55,24 +54,20 @@ public class LetterKeywordQueryDslRepository {
                 .select(qLetter.id)
                 .from(qLetter)
                 .where(qLetter.id.notIn(excludedLetterIds)
-                        .and(qLetter.isDeleted.eq(false)))
+                        .and(qLetter.isDeleted.isFalse()))
                 .orderBy(Expressions.stringTemplate("function('RAND')").asc())
                 .limit(limit)
                 .fetch();
     }
 
-    public List<LetterKeywordEntity> getFrequentKeywords(List<Long> letterIds) {
+    public List<String> getFrequentKeywords(List<Long> letterIds) {
         QLetterKeywordEntity letterKeyword = QLetterKeywordEntity.letterKeywordEntity;
 
         return queryFactory
-                .select(Projections.constructor(LetterKeywordEntity.class,
-                        letterKeyword.letterId.min(),
-                        letterKeyword.keyword,
-                        letterKeyword.isDeleted
-                ))
+                .select(letterKeyword.keyword)
                 .from(letterKeyword)
                 .where(letterKeyword.letterId.in(letterIds)
-                        .and(letterKeyword.isDeleted.eq(false)))
+                        .and(letterKeyword.isDeleted.isFalse()))
                 .groupBy(letterKeyword.keyword)
                 .orderBy(letterKeyword.keyword.count().desc())
                 .limit(5)

--- a/src/main/java/postman/bottler/keyword/infra/LetterKeywordRepositoryImpl.java
+++ b/src/main/java/postman/bottler/keyword/infra/LetterKeywordRepositoryImpl.java
@@ -3,9 +3,9 @@ package postman.bottler.keyword.infra;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import postman.bottler.keyword.application.repository.LetterKeywordRepository;
 import postman.bottler.keyword.domain.LetterKeyword;
 import postman.bottler.keyword.infra.entity.LetterKeywordEntity;
-import postman.bottler.keyword.application.repository.LetterKeywordRepository;
 
 @Repository
 @RequiredArgsConstructor
@@ -37,9 +37,7 @@ public class LetterKeywordRepositoryImpl implements LetterKeywordRepository {
     }
 
     @Override
-    public List<LetterKeyword> getFrequentKeywords(List<Long> letterIds) {
-        return queryDslRepository.getFrequentKeywords(letterIds).stream()
-                .map(LetterKeywordEntity::toDomain)
-                .toList();
+    public List<String> getFrequentKeywords(List<Long> letterIds) {
+        return queryDslRepository.getFrequentKeywords(letterIds);
     }
 }

--- a/src/test/java/postman/bottler/keyword/application/service/LetterKeywordServiceTest.java
+++ b/src/test/java/postman/bottler/keyword/application/service/LetterKeywordServiceTest.java
@@ -103,10 +103,10 @@ class LetterKeywordServiceTest extends TestBase {
         // given
         Long userId = 1L;
         List<Long> letterIds = List.of(1L, 2L, 3L);
-        List<LetterKeyword> mockFrequentKeywords = List.of(
-                LetterKeyword.from(1L, "사랑"),
-                LetterKeyword.from(2L, "행복"),
-                LetterKeyword.from(3L, "우정")
+        List<String> mockFrequentKeywords = List.of(
+                "사랑",
+                "행복",
+                "우정"
         );
 
         when(letterService.findIdsByUserId(userId)).thenReturn(letterIds);

--- a/src/test/java/postman/bottler/keyword/infra/LetterKeywordRepositoryImplTest.java
+++ b/src/test/java/postman/bottler/keyword/infra/LetterKeywordRepositoryImplTest.java
@@ -42,6 +42,11 @@ class LetterKeywordRepositoryImplTest extends TestBase {
             LetterKeywordEntity.builder().letterId(1L).keyword("keyword2").isDeleted(false).build()
     );
 
+    private static final List<String> MOCK_KEYWORDS_STRING = List.of(
+            "keyword1",
+            "keyword2"
+    );
+
     @Test
     @DisplayName("키워드 리스트 저장")
     void saveAll() {
@@ -107,14 +112,14 @@ class LetterKeywordRepositoryImplTest extends TestBase {
     void getFrequentKeywords() {
         // given
         List<Long> letterIds = List.of(1L, 2L);
-        when(queryDslRepository.getFrequentKeywords(letterIds)).thenReturn(MOCK_KEYWORD_ENTITIES);
+        when(queryDslRepository.getFrequentKeywords(letterIds)).thenReturn(MOCK_KEYWORDS_STRING);
 
         // when
-        List<LetterKeyword> frequentKeywords = repository.getFrequentKeywords(letterIds);
+        List<String> frequentKeywords = repository.getFrequentKeywords(letterIds);
 
         // then
         assertThat(frequentKeywords).hasSize(2);
-        assertThat(frequentKeywords.get(0).getKeyword()).isEqualTo("keyword1");
+        assertThat(frequentKeywords).isIn("keyword1", "keyword2");
         verify(queryDslRepository, times(1)).getFrequentKeywords(letterIds);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명 
- 기존 @Transactional(readOnly = true) 사용 시, 트랜잭션 커밋 전 최신 데이터 조회 불가
- @Transactional(propagation = Propagation.REQUIRES_NEW) 적용하여 독립 트랜잭션에서 최신 데이터 조회 가능하도록 변경
- QueryDSL에서 직접 List<String> 반환하도록 개선하여 데이터 정합성 유지<br>

## 연결된 issue
연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #294 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
