### PR TITLE
Feature/#298 지도편지 전체 삭제, 받은 사람 마이페이지에서 삭제 기능 추가

### DIFF
--- a/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteMapLettersRequestDTO.java
+++ b/src/main/java/postman/bottler/mapletter/application/dto/request/DeleteMapLettersRequestDTO.java
@@ -1,7 +1,6 @@
 package postman.bottler.mapletter.application.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.List;
 import postman.bottler.mapletter.exception.TypeNotFoundException;
 

--- a/src/main/java/postman/bottler/mapletter/application/repository/MapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/MapLetterRepository.java
@@ -42,4 +42,6 @@ public interface MapLetterRepository {
     void updateRead(MapLetter mapLetter);
 
     void softDeleteAllByCreateUserId(Long userId);
+
+    void softDeleteForRecipient(Long letterId);
 }

--- a/src/main/java/postman/bottler/mapletter/application/repository/MapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/MapLetterRepository.java
@@ -40,4 +40,6 @@ public interface MapLetterRepository {
     List<MapLetter> findAllByIds(List<Long> ids);
 
     void updateRead(MapLetter mapLetter);
+
+    void softDeleteAllByCreateUserId(Long userId);
 }

--- a/src/main/java/postman/bottler/mapletter/application/repository/MapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/MapLetterRepository.java
@@ -44,4 +44,6 @@ public interface MapLetterRepository {
     void softDeleteAllByCreateUserId(Long userId);
 
     void softDeleteForRecipient(Long letterId);
+
+    void softDeleteAllForRecipient(Long userId);
 }

--- a/src/main/java/postman/bottler/mapletter/application/repository/RecentReplyStorage.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/RecentReplyStorage.java
@@ -1,0 +1,11 @@
+package postman.bottler.mapletter.application.repository;
+
+import java.util.List;
+
+public interface RecentReplyStorage {
+    List<Object> getRecentReplies(Long userId);
+
+    void saveRecentReply(Long userId, String type, Long letterId, String labelUrl);
+
+    void deleteRecentReply(Long userId, String type, Long letterId, String labelUrl);
+}

--- a/src/main/java/postman/bottler/mapletter/application/repository/ReplyMapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/ReplyMapLetterRepository.java
@@ -29,4 +29,6 @@ public interface ReplyMapLetterRepository {
     List<ReplyProjectDTO> findRecentMapKeywordReplyByUserId(Long userId, int fetchItemSize);
 
     void softDeleteAllByCreateUserId(Long userId);
+
+    void softDeleteForRecipient(Long letterId);
 }

--- a/src/main/java/postman/bottler/mapletter/application/repository/ReplyMapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/ReplyMapLetterRepository.java
@@ -31,4 +31,6 @@ public interface ReplyMapLetterRepository {
     void softDeleteAllByCreateUserId(Long userId);
 
     void softDeleteForRecipient(Long letterId);
+
+    void softDeleteAllForRecipient(Long userId);
 }

--- a/src/main/java/postman/bottler/mapletter/application/repository/ReplyMapLetterRepository.java
+++ b/src/main/java/postman/bottler/mapletter/application/repository/ReplyMapLetterRepository.java
@@ -27,4 +27,6 @@ public interface ReplyMapLetterRepository {
     Page<ReplyMapLetter> findAllSentReplyByUserId(Long userId, PageRequest pageRequest);
 
     List<ReplyProjectDTO> findRecentMapKeywordReplyByUserId(Long userId, int fetchItemSize);
+
+    void softDeleteAllByCreateUserId(Long userId);
 }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -509,6 +509,13 @@ public class MapLetterService {
             case "SENT":
                 mapLetterRepository.softDeleteAllByCreateUserId(userId);
                 replyMapLetterRepository.softDeleteAllByCreateUserId(userId);
+                break;
+            case "SENT-MAP":
+                mapLetterRepository.softDeleteAllByCreateUserId(userId);
+                break;
+            case "SENT-REPLY":
+                replyMapLetterRepository.softDeleteAllByCreateUserId(userId);
+                break;
         }
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -50,6 +50,7 @@ import postman.bottler.mapletter.exception.LetterAlreadyReplyException;
 import postman.bottler.mapletter.exception.MapLetterAlreadyArchivedException;
 import postman.bottler.mapletter.exception.MapLetterNotFoundException;
 import postman.bottler.mapletter.exception.PageRequestException;
+import postman.bottler.mapletter.exception.TypeNotFoundException;
 import postman.bottler.notification.application.dto.request.NotificationLabelRequestDTO;
 import postman.bottler.notification.application.service.NotificationService;
 import postman.bottler.user.application.service.UserService;
@@ -463,6 +464,8 @@ public class MapLetterService {
                     replyRedisService.deleteRecentReply(letter.letterId(), replyMapLetter.getLabel(),
                             replyMapLetter.getSourceLetterId());
                     break;
+                default:
+                    throw new TypeNotFoundException("잘못된 타입입니다.");
             }
         }
     }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -465,7 +465,7 @@ public class MapLetterService {
                             replyMapLetter.getSourceLetterId());
                     break;
                 default:
-                    throw new TypeNotFoundException("잘못된 타입입니다.");
+                    throw new TypeNotFoundException("잘못된 편지 타입입니다.");
             }
         }
     }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -260,7 +260,8 @@ public class MapLetterService {
 
     @Transactional
     public void deleteArchivedLetter(DeleteArchivedLettersRequestDTO deleteArchivedLettersRequestDTO, Long userId) {
-        List<MapLetterArchive> archiveInfos = mapLetterArchiveRepository.findAllById(deleteArchivedLettersRequestDTO.letterIds());
+        List<MapLetterArchive> archiveInfos = mapLetterArchiveRepository.findAllById(
+                deleteArchivedLettersRequestDTO.letterIds());
 
         if (archiveInfos.size() != deleteArchivedLettersRequestDTO.letterIds().size()) {
             throw new MapLetterNotFoundException("편지를 찾을 수 없습니다.");
@@ -274,7 +275,8 @@ public class MapLetterService {
     }
 
     @Transactional
-    public void deleteArchivedLetter(DeleteArchivedLettersRequestDTOV1 deleteArchivedLettersRequestDTO, Long userId) { //삭제 예정
+    public void deleteArchivedLetter(DeleteArchivedLettersRequestDTOV1 deleteArchivedLettersRequestDTO,
+                                     Long userId) { //삭제 예정
         for (Long archiveId : deleteArchivedLettersRequestDTO.archiveIds()) {
             MapLetterArchive findArchiveInfo = mapLetterArchiveRepository.findById(archiveId);
             findArchiveInfo.validDeleteArchivedLetter(userId);
@@ -484,7 +486,7 @@ public class MapLetterService {
     @Transactional
     public void deleteMapLetters(DeleteMapLettersRequestDTO letters, Long userId) {
         for (LetterInfo letter : letters.letters()) {
-            switch (letter.letterType()){
+            switch (letter.letterType()) {
                 case MAP:
                     MapLetter findMapLetter = mapLetterRepository.findById(letter.letterId());
                     findMapLetter.validDeleteMapLetter(userId);
@@ -498,6 +500,15 @@ public class MapLetterService {
                     deleteRecentReply(letter.letterId(), replyMapLetter.getLabel(), replyMapLetter.getSourceLetterId());
                     break;
             }
+        }
+    }
+
+    @Transactional
+    public void deleteAllMapLetters(String type, Long userId) {
+        switch (type) {
+            case "SENT":
+                mapLetterRepository.softDeleteAllByCreateUserId(userId);
+                replyMapLetterRepository.softDeleteAllByCreateUserId(userId);
         }
     }
 }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -448,29 +448,6 @@ public class MapLetterService {
     }
 
     @Transactional
-    public void deleteMapLetters(DeleteMapLettersRequestDTO letters, Long userId) {
-        for (LetterInfo letter : letters.letters()) {
-            switch (letter.letterType()) {
-                case MAP:
-                    MapLetter findMapLetter = mapLetterRepository.findById(letter.letterId());
-                    findMapLetter.validDeleteMapLetter(userId);
-                    mapLetterRepository.softDelete(letter.letterId());
-                    break;
-                case REPLY:
-                    ReplyMapLetter replyMapLetter = replyMapLetterRepository.findById(letter.letterId());
-                    replyMapLetter.validDeleteReplyMapLetter(userId);
-                    replyMapLetterRepository.softDelete(letter.letterId());
-
-                    replyRedisService.deleteRecentReply(letter.letterId(), replyMapLetter.getLabel(),
-                            replyMapLetter.getSourceLetterId());
-                    break;
-                default:
-                    throw new TypeNotFoundException("잘못된 편지 타입입니다.");
-            }
-        }
-    }
-
-    @Transactional
     public void deleteAllMapLetters(String type, Long userId) {
         switch (type) {
             case "SENT":

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -485,4 +485,27 @@ public class MapLetterService {
                 break;
         }
     }
+
+    @Transactional
+    public void deleteSentMapLetters(DeleteMapLettersRequestDTO letters, Long userId) {
+        for (LetterInfo letter : letters.letters()) {
+            switch (letter.letterType()) {
+                case MAP:
+                    MapLetter findMapLetter = mapLetterRepository.findById(letter.letterId());
+                    findMapLetter.validDeleteMapLetter(userId);
+                    mapLetterRepository.softDelete(letter.letterId());
+                    break;
+                case REPLY:
+                    ReplyMapLetter replyMapLetter = replyMapLetterRepository.findById(letter.letterId());
+                    replyMapLetter.validDeleteReplyMapLetter(userId);
+                    replyMapLetterRepository.softDelete(letter.letterId());
+
+                    replyRedisService.deleteRecentReply(letter.letterId(), replyMapLetter.getLabel(),
+                            replyMapLetter.getSourceLetterId());
+                    break;
+                default:
+                    throw new TypeNotFoundException("잘못된 편지 타입입니다.");
+            }
+        }
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/MapLetterService.java
@@ -483,6 +483,18 @@ public class MapLetterService {
             case "SENT-REPLY":
                 replyMapLetterRepository.softDeleteAllByCreateUserId(userId);
                 break;
+            case "RECEIVED":
+                mapLetterRepository.softDeleteAllForRecipient(userId);
+                replyMapLetterRepository.softDeleteAllForRecipient(userId);
+                break;
+            case "RECEIVED-MAP":
+                mapLetterRepository.softDeleteAllForRecipient(userId);
+                break;
+            case "RECEIVED-REPLY":
+                replyMapLetterRepository.softDeleteAllForRecipient(userId);
+                break;
+            default:
+                throw new TypeNotFoundException("잘못된 편지 타입입니다.");
         }
     }
 

--- a/src/main/java/postman/bottler/mapletter/application/service/ReplyRedisService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/ReplyRedisService.java
@@ -24,7 +24,6 @@ public class ReplyRedisService {
     public void fetchRecentReply(Long userId) {
         List<Object> redisValues = replyLetterRedisRepository.getRecentReplies(userId);
         int fetchItemSize = REDIS_SAVED_REPLY - (redisValues == null ? 0 : redisValues.size());
-        System.out.println(fetchItemSize);
 
         // Redis에 저장된 값이 부족하면 DB에서 조회 후 Redis에 저장
         if (fetchItemSize > 0) {

--- a/src/main/java/postman/bottler/mapletter/application/service/ReplyRedisService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/ReplyRedisService.java
@@ -31,7 +31,7 @@ public class ReplyRedisService {
             List<ReplyProjectDTO> recentMapKeywordReplyByUserId =
                     replyMapLetterRepository.findRecentMapKeywordReplyByUserId(userId, fetchItemSize);
 
-            String key="REPLY:"+userId;
+            String key = "REPLY:" + userId;
 
             List<ReplyProjectDTO> reversedList = new ArrayList<>(recentMapKeywordReplyByUserId);
             Collections.reverse(reversedList);

--- a/src/main/java/postman/bottler/mapletter/application/service/ReplyRedisService.java
+++ b/src/main/java/postman/bottler/mapletter/application/service/ReplyRedisService.java
@@ -1,0 +1,66 @@
+package postman.bottler.mapletter.application.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import postman.bottler.mapletter.application.dto.ReplyProjectDTO;
+import postman.bottler.mapletter.application.repository.MapLetterRepository;
+import postman.bottler.mapletter.application.repository.ReplyMapLetterRepository;
+import postman.bottler.mapletter.domain.MapLetter;
+import postman.bottler.mapletter.infra.ReplyLetterRedisRepository;
+import postman.bottler.reply.application.dto.ReplyType;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyRedisService {
+    private final ReplyLetterRedisRepository replyLetterRedisRepository;
+    private final ReplyMapLetterRepository replyMapLetterRepository;
+
+    private static final int REDIS_SAVED_REPLY = 6;
+    private final MapLetterRepository mapLetterRepository;
+
+    public void fetchRecentReply(Long userId) {
+        List<Object> redisValues = replyLetterRedisRepository.getRecentReplies(userId);
+        int fetchItemSize = REDIS_SAVED_REPLY - (redisValues == null ? 0 : redisValues.size());
+        System.out.println(fetchItemSize);
+
+        // Redis에 저장된 값이 부족하면 DB에서 조회 후 Redis에 저장
+        if (fetchItemSize > 0) {
+            List<ReplyProjectDTO> recentMapKeywordReplyByUserId =
+                    replyMapLetterRepository.findRecentMapKeywordReplyByUserId(userId, fetchItemSize);
+
+            String key="REPLY:"+userId;
+
+            List<ReplyProjectDTO> reversedList = new ArrayList<>(recentMapKeywordReplyByUserId);
+            Collections.reverse(reversedList);
+
+            List<Object> existingValues = replyLetterRedisRepository.getRecentReplies(userId);
+
+            for (ReplyProjectDTO reply : reversedList) {
+                String tempValue = reply.getType() + ":" + reply.getId() + ":" + reply.getLabel();
+
+                if (existingValues == null || !existingValues.contains(tempValue)) {
+                    replyLetterRedisRepository.saveRecentReply(key, tempValue);
+                }
+            }
+        }
+    }
+
+    public void saveRecentReply(Long letterId, String labelUrl, Long sourceLetterId) {
+        MapLetter sourceLetter = mapLetterRepository.findById(sourceLetterId);
+        String key = "REPLY:" + sourceLetter.getCreateUserId();
+        String value = ReplyType.MAP + ":" + letterId + ":" + labelUrl;
+
+        replyLetterRedisRepository.saveRecentReply(key, value);
+    }
+
+    public void deleteRecentReply(Long letterId, String labelUrl, Long sourceLetterId) {
+        MapLetter sourceLetter = mapLetterRepository.findById(sourceLetterId);
+        String key = "REPLY:" + sourceLetter.getCreateUserId();
+        String value = ReplyType.MAP + ":" + letterId + ":" + labelUrl;
+
+        replyLetterRedisRepository.deleteRecentReply(key, value);
+    }
+}

--- a/src/main/java/postman/bottler/mapletter/domain/MapLetter.java
+++ b/src/main/java/postman/bottler/mapletter/domain/MapLetter.java
@@ -36,6 +36,7 @@ public class MapLetter {
     private boolean isDeleted;
     private boolean isBlocked;
     private boolean isRead;
+    private boolean isRecipientDeleted;
 
     public static MapLetter createPublicMapLetter(CreatePublicMapLetterRequestDTO createPublicMapLetterRequestDTO,
                                                   Long userId) {
@@ -55,6 +56,7 @@ public class MapLetter {
                 .isBlocked(false)
                 .isRead(false)
                 .description(createPublicMapLetterRequestDTO.description())
+                .isRecipientDeleted(false)
                 .build();
     }
 
@@ -77,11 +79,16 @@ public class MapLetter {
                 .isBlocked(false)
                 .isRead(false)
                 .description(createTargetMapLetterRequestDTO.description())
+                .isRecipientDeleted(false)
                 .build();
     }
 
     public void updateDelete(boolean deleted) {
         this.isDeleted = deleted;
+    }
+
+    public void updateRecipientDeleted(boolean deleted) {
+        this.isRecipientDeleted = deleted;
     }
 
     public void validateFindOneMapLetter(double viewDistance, Double distance) {
@@ -139,5 +146,17 @@ public class MapLetter {
 
     public boolean isTargetUser(Long userId) {
         return this.targetUserId != null && this.targetUserId.equals(userId);
+    }
+
+    public void validateRecipientDeletion(Long userId) {
+        if (this.getTargetUserId() == null || !this.getTargetUserId().equals(userId)) {
+            throw new CommonForbiddenException("편지를 삭제 할 권한이 없습니다. 편지 삭제에 실패하였습니다.");
+        }
+        if (this.isBlocked()) {
+            throw new BlockedLetterException("해당 편지는 신고당한 편지입니다.");
+        }
+        if (this.isRecipientDeleted()) {
+            throw new MapLetterAlreadyDeletedException("해당 편지는 이미 삭제되었습니다.");
+        }
     }
 }

--- a/src/main/java/postman/bottler/mapletter/domain/ReplyMapLetter.java
+++ b/src/main/java/postman/bottler/mapletter/domain/ReplyMapLetter.java
@@ -84,7 +84,7 @@ public class ReplyMapLetter {
         if (this.isBlocked()) {
             throw new BlockedLetterException("해당 편지는 신고당한 편지입니다.");
         }
-        if(this.isRecipientDeleted()){
+        if (this.isRecipientDeleted()) {
             throw new MapLetterAlreadyDeletedException("해당 편지는 이미 삭제되었습니다.");
         }
     }

--- a/src/main/java/postman/bottler/mapletter/domain/ReplyMapLetter.java
+++ b/src/main/java/postman/bottler/mapletter/domain/ReplyMapLetter.java
@@ -27,6 +27,7 @@ public class ReplyMapLetter {
     private Long createUserId;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private boolean isRecipientDeleted;
 
     public static ReplyMapLetter createReplyMapLetter(CreateReplyMapLetterRequestDTO createReplyMapLetterRequestDTO,
                                                       Long userId) {
@@ -41,11 +42,16 @@ public class ReplyMapLetter {
                 .createUserId(userId)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
+                .isRecipientDeleted(false)
                 .build();
     }
 
     public void updateDelete(boolean deleted) {
         this.isDeleted = deleted;
+    }
+
+    public void updateRecipientDeleted(boolean deleted) {
+        this.isRecipientDeleted = deleted;
     }
 
     public void validFindOneReplyMapLetter(Long userId, MapLetter sourceLetter) {
@@ -68,6 +74,18 @@ public class ReplyMapLetter {
         }
         if (this.isBlocked()) {
             throw new BlockedLetterException("해당 편지는 신고당한 편지입니다.");
+        }
+    }
+
+    public void validateRecipientDeletion(Long userId, Long sourceLetterCreateUserId) {
+        if (!sourceLetterCreateUserId.equals(userId)) {
+            throw new CommonForbiddenException("편지를 삭제 할 권한이 없습니다. 편지 삭제에 실패하였습니다.");
+        }
+        if (this.isBlocked()) {
+            throw new BlockedLetterException("해당 편지는 신고당한 편지입니다.");
+        }
+        if(this.isRecipientDeleted()){
+            throw new MapLetterAlreadyDeletedException("해당 편지는 이미 삭제되었습니다.");
         }
     }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterJpaRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterJpaRepository.java
@@ -129,4 +129,6 @@ public interface MapLetterJpaRepository extends JpaRepository<MapLetterEntity, L
     List<MapLetterAndDistance> guestFindLettersByUserLocation(BigDecimal latitude, BigDecimal longitude);
 
     List<MapLetterEntity> findAllByCreateUserId(Long createUserId);
+
+    List<MapLetterEntity> findAllByTargetUserId(Long targetUserId);
 }

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterJpaRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterJpaRepository.java
@@ -22,7 +22,7 @@ public interface MapLetterJpaRepository extends JpaRepository<MapLetterEntity, L
     Page<MapLetterEntity> findActiveByCreateUserId(Long userId, Pageable pageable);
 
     @Query("SELECT m FROM MapLetterEntity m "
-            + "WHERE m.targetUserId = :userId AND m.isDeleted = false AND m.isBlocked=false ORDER BY m.createdAt DESC")
+            + "WHERE m.targetUserId = :userId AND m.isDeleted = false AND m.isBlocked=false AND m.isRecipientDeleted = false ORDER BY m.createdAt DESC")
     Page<MapLetterEntity> findActiveByTargetUserId(Long userId, Pageable pageable);
 
     @Query(value = "SELECT m.map_letter_id as letterId, m.latitude, m.longitude, m.title, m.description, "
@@ -94,7 +94,8 @@ public interface MapLetterJpaRepository extends JpaRepository<MapLetterEntity, L
             "m.label AS label, NULL AS sourceLetterId, 'TARGET' AS type, m.created_at AS createdAt, m.create_user_id as senderId, m.is_read as isRead  "
             +
             "FROM map_letter m " +
-            "WHERE m.target_user_id = :userId AND m.is_deleted = false AND m.is_blocked = false " +
+            "WHERE m.target_user_id = :userId AND m.is_deleted = false AND m.is_blocked = false AND m.is_recipient_deleted = false "
+            +
             "UNION ALL " +
             "SELECT r.reply_letter_id AS letterId, "
             + "CONCAT('Re: ', (SELECT ml.title FROM map_letter ml WHERE ml.map_letter_id = r.source_letter_id)) AS title, "
@@ -102,14 +103,16 @@ public interface MapLetterJpaRepository extends JpaRepository<MapLetterEntity, L
             + "r.label AS label, r.source_letter_id AS sourceLetterId, 'REPLY' AS type, r.created_at AS createdAt, r.create_user_id as senderId, false as isRead "
             +
             "FROM reply_map_letter r " +
-            "WHERE r.create_user_id = :userId AND r.is_deleted = false AND r.is_blocked = false " +
+            "WHERE r.create_user_id = :userId AND r.is_deleted = false AND r.is_blocked = false AND r.is_recipient_deleted = false "
+            +
             "ORDER BY createdAt DESC",
             countQuery = "SELECT COUNT(*) FROM (" +
                     "SELECT m.map_letter_id FROM map_letter m " +
-                    "WHERE m.target_user_id = :userId AND m.is_deleted = false AND m.is_blocked = false " +
+                    "WHERE m.target_user_id = :userId AND m.is_deleted = false AND m.is_blocked = false AND m.is_recipient_deleted = false "
+                    +
                     "UNION ALL " +
                     "SELECT r.reply_letter_id FROM reply_map_letter r " +
-                    "WHERE r.create_user_id = :userId AND r.is_deleted = false AND r.is_blocked = false) AS combined",
+                    "WHERE r.create_user_id = :userId AND r.is_deleted = false AND r.is_blocked = false AND r.is_recipient_deleted = false) AS combined",
             nativeQuery = true)
     Page<FindReceivedMapLetterDTO> findActiveReceivedMapLettersByUserId(Long userId, PageRequest pageRequest);
 

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterJpaRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterJpaRepository.java
@@ -124,4 +124,6 @@ public interface MapLetterJpaRepository extends JpaRepository<MapLetterEntity, L
                      AND TIMESTAMPDIFF(DAY, m.created_at, NOW()) <= 30
             """, nativeQuery = true)
     List<MapLetterAndDistance> guestFindLettersByUserLocation(BigDecimal latitude, BigDecimal longitude);
+
+    List<MapLetterEntity> findAllByCreateUserId(Long createUserId);
 }

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
@@ -22,7 +22,6 @@ import postman.bottler.mapletter.application.repository.MapLetterRepository;
 @RequiredArgsConstructor
 public class MapLetterRepositoryImpl implements MapLetterRepository {
     private final MapLetterJpaRepository mapLetterJpaRepository;
-    private final EntityManager em;
 
     @Override
     public MapLetter save(MapLetter mapLetter) {
@@ -111,7 +110,7 @@ public class MapLetterRepositoryImpl implements MapLetterRepository {
     @Override
     public void updateRead(MapLetter mapLetter) {
         MapLetterEntity mapLetterEntity = mapLetterJpaRepository.findById(mapLetter.getId())
-                        .orElseThrow(()->new MapLetterNotFoundException("해당 편지를 찾을 수 없습니다."));
+                .orElseThrow(() -> new MapLetterNotFoundException("해당 편지를 찾을 수 없습니다."));
         mapLetterEntity.updateRead();
     }
 
@@ -124,5 +123,12 @@ public class MapLetterRepositoryImpl implements MapLetterRepository {
         }
 
         mapLetterEntities.forEach(mapLetterEntity -> mapLetterEntity.updateDelete(true));
+    }
+
+    @Override
+    public void softDeleteForRecipient(Long letterId) {
+        MapLetterEntity deleteLetter = mapLetterJpaRepository.findById(letterId)
+                .orElseThrow(() -> new MapLetterNotFoundException("편지를 찾을 수 없습니다."));
+        deleteLetter.updateRecipientDeleted(true);
     }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
@@ -131,4 +131,15 @@ public class MapLetterRepositoryImpl implements MapLetterRepository {
                 .orElseThrow(() -> new MapLetterNotFoundException("편지를 찾을 수 없습니다."));
         deleteLetter.updateRecipientDeleted(true);
     }
+
+    @Override
+    public void softDeleteAllForRecipient(Long userId) {
+        List<MapLetterEntity> mapLetterEntities = mapLetterJpaRepository.findAllByTargetUserId(userId);
+
+        if (mapLetterEntities.isEmpty()) {
+            throw new MapLetterNotFoundException("삭제 할 편지가 없습니다.");
+        }
+
+        mapLetterEntities.forEach(mapLetterEntity -> mapLetterEntity.updateRecipientDeleted(true));
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/MapLetterRepositoryImpl.java
@@ -3,6 +3,7 @@ package postman.bottler.mapletter.infra;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -112,5 +113,16 @@ public class MapLetterRepositoryImpl implements MapLetterRepository {
         MapLetterEntity mapLetterEntity = mapLetterJpaRepository.findById(mapLetter.getId())
                         .orElseThrow(()->new MapLetterNotFoundException("해당 편지를 찾을 수 없습니다."));
         mapLetterEntity.updateRead();
+    }
+
+    @Override
+    public void softDeleteAllByCreateUserId(Long userId) {
+        List<MapLetterEntity> mapLetterEntities = mapLetterJpaRepository.findAllByCreateUserId(userId);
+
+        if (mapLetterEntities.isEmpty()) {
+            throw new MapLetterNotFoundException("삭제할 편지가 없습니다.");
+        }
+
+        mapLetterEntities.forEach(mapLetterEntity -> mapLetterEntity.updateDelete(true));
     }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyLetterRedisRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyLetterRedisRepository.java
@@ -1,0 +1,33 @@
+package postman.bottler.mapletter.infra;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyLetterRedisRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final int REDIS_SAVED_REPLY = 6;
+
+    public void saveRecentReply(String key, String value) {
+        Long size = redisTemplate.opsForList().size(key);
+        if (size != null && size >= REDIS_SAVED_REPLY) {
+            redisTemplate.opsForList().rightPop(key);
+        }
+
+        if (!redisTemplate.opsForList().range(key, 0, -1).contains(value)) {
+            redisTemplate.opsForList().leftPush(key, value);
+        }
+    }
+
+    public void deleteRecentReply(String key, String value) {
+        redisTemplate.opsForList().remove(key, 1, value);
+    }
+
+    public List<Object> getRecentReplies(Long userId) {
+        String key = "REPLY:" + userId;
+        return redisTemplate.opsForList().range(key, 0, -1);
+    }
+}

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyLetterRedisRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyLetterRedisRepository.java
@@ -4,14 +4,27 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
+import postman.bottler.mapletter.application.repository.RecentReplyStorage;
 
 @Repository
 @RequiredArgsConstructor
-public class ReplyLetterRedisRepository {
+public class ReplyLetterRedisRepository implements RecentReplyStorage {
     private final RedisTemplate<String, Object> redisTemplate;
-    private static final int REDIS_SAVED_REPLY = 6;
 
-    public void saveRecentReply(String key, String value) {
+    private static final int REDIS_SAVED_REPLY = 6;
+    private static final String RECENT_REPLY_KEY_PREFIX = "REPLY:";
+
+    @Override
+    public List<Object> getRecentReplies(Long userId) {
+        String key = createKey(userId);
+        return redisTemplate.opsForList().range(key, 0, -1);
+    }
+
+    @Override
+    public void saveRecentReply(Long userId, String type, Long letterId, String labelUrl) {
+        String key = createKey(userId);
+        String value = createValue(type, letterId, labelUrl);
+
         Long size = redisTemplate.opsForList().size(key);
         if (size != null && size >= REDIS_SAVED_REPLY) {
             redisTemplate.opsForList().rightPop(key);
@@ -22,12 +35,18 @@ public class ReplyLetterRedisRepository {
         }
     }
 
-    public void deleteRecentReply(String key, String value) {
+    @Override
+    public void deleteRecentReply(Long userId, String type, Long letterId, String labelUrl) {
+        String key = createKey(userId);
+        String value = createValue(type, letterId, labelUrl);
         redisTemplate.opsForList().remove(key, 1, value);
     }
 
-    public List<Object> getRecentReplies(Long userId) {
-        String key = "REPLY:" + userId;
-        return redisTemplate.opsForList().range(key, 0, -1);
+    private String createKey(Long userId) {
+        return RECENT_REPLY_KEY_PREFIX + userId;
+    }
+
+    private String createValue(String type, Long letterId, String labelUrl) {
+        return type + ":" + letterId + ":" + labelUrl;
     }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterJpaRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterJpaRepository.java
@@ -52,4 +52,10 @@ public interface ReplyMapLetterJpaRepository extends JpaRepository<ReplyMapLette
     List<ReplyProjectDTO> findRecentMapKeywordReplyByUserId(Long userId, int fetchItemSize);
 
     List<ReplyMapLetterEntity> findAllByCreateUserId(Long createUserId);
+
+    @Query(value = """
+                 SELECT r FROM MapLetterEntity m, ReplyMapLetterEntity r
+                 WHERE m.mapLetterId = r.sourceLetterId AND m.createUserId=:userId
+            """)
+    List<ReplyMapLetterEntity> findAllBySourceLetterCreateUserId(Long userId);
 }

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterJpaRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterJpaRepository.java
@@ -40,11 +40,11 @@ public interface ReplyMapLetterJpaRepository extends JpaRepository<ReplyMapLette
                     SELECT r.reply_letter_id as id, r.created_at, r.label, 'MAP' as type
                     FROM reply_map_letter r
                     JOIN map_letter m ON r.source_letter_id = m.map_letter_id
-                    WHERE m.create_user_id=:userId
+                    WHERE m.create_user_id=:userId AND r.is_deleted=false AND r.is_blocked = false 
                         UNION ALL
                     SELECT rl.id AS id, rl.created_at, rl.label, 'KEYWORD' as type
                     FROM reply_letters rl
-                    WHERE rl.receiver_id=:userId
+                    WHERE rl.receiver_id=:userId AND rl.is_blocked=false AND rl.is_deleted=false 
                 ) combined
                 ORDER BY created_at DESC
                 LIMIT :fetchItemSize

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterJpaRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterJpaRepository.java
@@ -17,7 +17,7 @@ import postman.bottler.mapletter.infra.entity.ReplyMapLetterEntity;
 public interface ReplyMapLetterJpaRepository extends JpaRepository<ReplyMapLetterEntity, Long> {
 
     @Query("SELECT r FROM ReplyMapLetterEntity r, MapLetterEntity m WHERE m.createUserId = :userId " +
-            "AND m.mapLetterId = r.sourceLetterId AND r.isDeleted=false AND r.isBlocked = false ORDER BY r.createdAt DESC ")
+            "AND m.mapLetterId = r.sourceLetterId AND r.isDeleted=false AND r.isBlocked = false AND r.isRecipientDeleted = false ORDER BY r.createdAt DESC ")
     Page<ReplyMapLetterEntity> findActiveReplyMapLettersBySourceUserId(Long userId, Pageable pageable);
 
     @Query("SELECT r FROM ReplyMapLetterEntity r " +

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterJpaRepository.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterJpaRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import postman.bottler.mapletter.application.dto.ReplyProjectDTO;
+import postman.bottler.mapletter.infra.entity.MapLetterEntity;
 import postman.bottler.mapletter.infra.entity.ReplyMapLetterEntity;
 
 @Repository
@@ -49,4 +50,6 @@ public interface ReplyMapLetterJpaRepository extends JpaRepository<ReplyMapLette
                 LIMIT :fetchItemSize
             """, nativeQuery = true)
     List<ReplyProjectDTO> findRecentMapKeywordReplyByUserId(Long userId, int fetchItemSize);
+
+    List<ReplyMapLetterEntity> findAllByCreateUserId(Long createUserId);
 }

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterRepositoryImpl.java
@@ -99,4 +99,15 @@ public class ReplyMapLetterRepositoryImpl implements ReplyMapLetterRepository {
 
         letter.updateRecipientDeleted(true);
     }
+
+    @Override
+    public void softDeleteAllForRecipient(Long userId) {
+        List<ReplyMapLetterEntity> letters = replyMapLetterJpaRepository.findAllBySourceLetterCreateUserId(userId);
+
+        if (letters.isEmpty()) {
+            throw new MapLetterNotFoundException("삭제할 편지가 없습니다.");
+        }
+
+        letters.forEach(letter -> letter.updateRecipientDeleted(true));
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterRepositoryImpl.java
@@ -91,4 +91,12 @@ public class ReplyMapLetterRepositoryImpl implements ReplyMapLetterRepository {
 
         letters.forEach(letter -> letter.updateDelete(true));
     }
+
+    @Override
+    public void softDeleteForRecipient(Long letterId) {
+        ReplyMapLetterEntity letter=replyMapLetterJpaRepository.findById(letterId)
+                .orElseThrow(()->new MapLetterNotFoundException("편지를 찾을 수 없습니다."));
+
+        letter.updateRecipientDeleted(true);
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterRepositoryImpl.java
@@ -81,4 +81,14 @@ public class ReplyMapLetterRepositoryImpl implements ReplyMapLetterRepository {
         return replyMapLetterJpaRepository.findRecentMapKeywordReplyByUserId(userId, fetchItemSize);
     }
 
+    @Override
+    public void softDeleteAllByCreateUserId(Long userId) {
+        List<ReplyMapLetterEntity> letters = replyMapLetterJpaRepository.findAllByCreateUserId(userId);
+
+        if (letters.isEmpty()) {
+            throw new MapLetterNotFoundException("삭제할 편지가 없습니다.");
+        }
+
+        letters.forEach(letter -> letter.updateDelete(true));
+    }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterRepositoryImpl.java
+++ b/src/main/java/postman/bottler/mapletter/infra/ReplyMapLetterRepositoryImpl.java
@@ -94,8 +94,8 @@ public class ReplyMapLetterRepositoryImpl implements ReplyMapLetterRepository {
 
     @Override
     public void softDeleteForRecipient(Long letterId) {
-        ReplyMapLetterEntity letter=replyMapLetterJpaRepository.findById(letterId)
-                .orElseThrow(()->new MapLetterNotFoundException("편지를 찾을 수 없습니다."));
+        ReplyMapLetterEntity letter = replyMapLetterJpaRepository.findById(letterId)
+                .orElseThrow(() -> new MapLetterNotFoundException("편지를 찾을 수 없습니다."));
 
         letter.updateRecipientDeleted(true);
     }

--- a/src/main/java/postman/bottler/mapletter/infra/entity/MapLetterEntity.java
+++ b/src/main/java/postman/bottler/mapletter/infra/entity/MapLetterEntity.java
@@ -60,12 +60,13 @@ public class MapLetterEntity {
     private boolean isDeleted;
     private boolean isBlocked;
     private boolean isRead;
+    private boolean isRecipientDeleted;
 
     @Builder
     public MapLetterEntity(String title, String content, BigDecimal latitude, BigDecimal longitude, String font,
                            String paper, String label, MapLetterType type, Long targetUserId, Long createUserId,
                            LocalDateTime createdAt, LocalDateTime updatedAt, boolean isDeleted, boolean isBlocked,
-                           String description, boolean isRead) {
+                           String description, boolean isRead, boolean isRecipientDeleted) {
         this.title = title;
         this.content = content;
         this.latitude = latitude;
@@ -82,6 +83,7 @@ public class MapLetterEntity {
         this.isBlocked = isBlocked;
         this.description = description;
         this.isRead = isRead;
+        this.isRecipientDeleted = isRecipientDeleted;
     }
 
     public static MapLetterEntity from(MapLetter mapLetter) {
@@ -102,6 +104,7 @@ public class MapLetterEntity {
                 .isBlocked(mapLetter.isBlocked())
                 .description(mapLetter.getDescription())
                 .isRead(mapLetter.isRead())
+                .isRecipientDeleted(mapLetter.isRecipientDeleted())
                 .build();
     }
 
@@ -124,6 +127,7 @@ public class MapLetterEntity {
                 .isBlocked(mapLetterEntity.isBlocked)
                 .description(mapLetterEntity.description)
                 .isRead(mapLetterEntity.isRead)
+                .isRecipientDeleted(mapLetterEntity.isRecipientDeleted)
                 .build();
     }
 
@@ -133,5 +137,9 @@ public class MapLetterEntity {
 
     public void updateRead() {
         this.isRead = true;
+    }
+
+    public void updateRecipientDeleted(boolean isRecipientDeleted) {
+        this.isRecipientDeleted = isRecipientDeleted;
     }
 }

--- a/src/main/java/postman/bottler/mapletter/infra/entity/ReplyMapLetterEntity.java
+++ b/src/main/java/postman/bottler/mapletter/infra/entity/ReplyMapLetterEntity.java
@@ -39,11 +39,12 @@ public class ReplyMapLetterEntity {
     private LocalDateTime updatedAt;
     @NotNull
     private Long createUserId;
+    private boolean isRecipientDeleted;
 
     @Builder
     public ReplyMapLetterEntity(Long replyLetterId, Long sourceLetterId, String font, String paper, String label,
                                 boolean isBlocked, boolean isDeleted, LocalDateTime createdAt, LocalDateTime updatedAt,
-                                Long createUserId, String content) {
+                                Long createUserId, String content, boolean isRecipientDeleted) {
         this.replyLetterId = replyLetterId;
         this.sourceLetterId = sourceLetterId;
         this.font = font;
@@ -55,6 +56,7 @@ public class ReplyMapLetterEntity {
         this.updatedAt = updatedAt;
         this.createUserId = createUserId;
         this.content = content;
+        this.isRecipientDeleted = isRecipientDeleted;
     }
 
     public static ReplyMapLetterEntity from(ReplyMapLetter replyMapLetter) {
@@ -70,6 +72,7 @@ public class ReplyMapLetterEntity {
                 .updatedAt(replyMapLetter.getUpdatedAt())
                 .createUserId(replyMapLetter.getCreateUserId())
                 .content(replyMapLetter.getContent())
+                .isRecipientDeleted(replyMapLetter.isRecipientDeleted())
                 .build();
     }
 
@@ -86,10 +89,15 @@ public class ReplyMapLetterEntity {
                 .updatedAt(replyMapLetter.getUpdatedAt())
                 .createUserId(replyMapLetter.getCreateUserId())
                 .content(replyMapLetter.getContent())
+                .isRecipientDeleted(replyMapLetter.isRecipientDeleted())
                 .build();
     }
 
     public void updateDelete(boolean isDeleted) {
         this.isDeleted = isDeleted;
+    }
+
+    public void updateRecipientDeleted(boolean isRecipientDeleted) {
+        this.isRecipientDeleted = isRecipientDeleted;
     }
 }

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -330,7 +330,7 @@ public class MapLetterController {
     public ApiResponse<?> deleteMapLetter(@RequestBody DeleteMapLettersRequestDTO deleteLetters,
                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
-        mapLetterService.deleteMapLetters(deleteLetters, userId);
+        mapLetterService.deleteSentMapLetters(deleteLetters, userId);
         return ApiResponse.onDeleteSuccess(deleteLetters);
     }
 

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -249,8 +249,8 @@ public class MapLetterController {
 
     @GetMapping("/saved")
     public ApiResponse<?> savedLettersV1(@RequestParam String type, @AuthenticationPrincipal CustomUserDetails user,
-                                       @RequestParam(defaultValue = "1") int page,
-                                       @RequestParam(defaultValue = "9") int size) {
+                                         @RequestParam(defaultValue = "1") int page,
+                                         @RequestParam(defaultValue = "9") int size) {
         Long userId = user.getUserId();
         return switch (type) {
             case "sent-all" -> //보낸 편지 전체 조회(지도편지, 답장 편지)

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -337,9 +337,18 @@ public class MapLetterController {
     @DeleteMapping("/sent")
     @Operation(summary = "보낸 편지 삭제", description = "로그인 필수. 지도편지, 답장편지 구분해서 보내주세요. 리스트 형태로 1개 ~ n개까지 삭제 가능")
     public ApiResponse<?> deleteSentMapLetter(@RequestBody DeleteMapLettersRequestDTO deleteLetters,
-                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();
         mapLetterService.deleteSentMapLetters(deleteLetters, userId);
+        return ApiResponse.onDeleteSuccess(deleteLetters);
+    }
+
+    @DeleteMapping("/received")
+    @Operation(summary = "받은 편지 삭제", description = "로그인 필수. 지도편지, 답장편지 구분해서 보내주세요. 리스트 형태로 1개 ~ n개까지 삭제 가능. 받은 편지 자체를 삭제하는게 아니라 받은 사람의 마이페이지에서만 삭제")
+    public ApiResponse<?> deleteReceivedMapLetter(@RequestBody DeleteMapLettersRequestDTO deleteLetters,
+                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        mapLetterService.deleteReceivedMapLetters(deleteLetters, userId);
         return ApiResponse.onDeleteSuccess(deleteLetters);
     }
 

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -353,7 +353,7 @@ public class MapLetterController {
     }
 
     @DeleteMapping("/all")
-    @Operation(summary = "편지 전체 삭제", description = "로그인 필수. 지도편지, 답장편지 구분해서 보내주세요. 리스트 형태로 1개 ~ n개까지 삭제 가능")
+    @Operation(summary = "편지 전체 삭제", description = "로그인 필수. 타입(SENT, SENT-MAP, SENT-REPLY) 나눠서 보내주세요")
     public ApiResponse<?> deleteAllMapLetter(@RequestParam String type,
                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -353,7 +353,7 @@ public class MapLetterController {
     }
 
     @DeleteMapping("/all")
-    @Operation(summary = "편지 전체 삭제", description = "로그인 필수. 타입(SENT, SENT-MAP, SENT-REPLY) 나눠서 보내주세요")
+    @Operation(summary = "편지 전체 삭제", description = "로그인 필수. 타입(SENT, SENT-MAP, SENT-REPLY, RECEIVED, RECEIVED-MAP, RECEIVED-REPLY) 나눠서 보내주세요")
     public ApiResponse<?> deleteAllMapLetter(@RequestParam String type,
                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUserId();

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -334,6 +334,15 @@ public class MapLetterController {
         return ApiResponse.onDeleteSuccess(deleteLetters);
     }
 
+    @DeleteMapping("/sent")
+    @Operation(summary = "보낸 편지 삭제", description = "로그인 필수. 지도편지, 답장편지 구분해서 보내주세요. 리스트 형태로 1개 ~ n개까지 삭제 가능")
+    public ApiResponse<?> deleteSentMapLetter(@RequestBody DeleteMapLettersRequestDTO deleteLetters,
+                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        mapLetterService.deleteSentMapLetters(deleteLetters, userId);
+        return ApiResponse.onDeleteSuccess(deleteLetters);
+    }
+
     @DeleteMapping("/all")
     @Operation(summary = "편지 전체 삭제", description = "로그인 필수. 지도편지, 답장편지 구분해서 보내주세요. 리스트 형태로 1개 ~ n개까지 삭제 가능")
     public ApiResponse<?> deleteAllMapLetter(@RequestParam String type,

--- a/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
+++ b/src/main/java/postman/bottler/mapletter/presentation/MapLetterController.java
@@ -333,4 +333,13 @@ public class MapLetterController {
         mapLetterService.deleteMapLetters(deleteLetters, userId);
         return ApiResponse.onDeleteSuccess(deleteLetters);
     }
+
+    @DeleteMapping("/all")
+    @Operation(summary = "편지 전체 삭제", description = "로그인 필수. 지도편지, 답장편지 구분해서 보내주세요. 리스트 형태로 1개 ~ n개까지 삭제 가능")
+    public ApiResponse<?> deleteAllMapLetter(@RequestParam String type,
+                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        mapLetterService.deleteAllMapLetters(type, userId);
+        return ApiResponse.onDeleteSuccess(type);
+    }
 }

--- a/src/main/java/postman/bottler/reply/application/service/ReplyService.java
+++ b/src/main/java/postman/bottler/reply/application/service/ReplyService.java
@@ -6,9 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import postman.bottler.mapletter.application.service.MapLetterService;
-import postman.bottler.mapletter.application.service.ReplyRedisService;
-import postman.bottler.mapletter.infra.ReplyLetterRedisRepository;
+import postman.bottler.mapletter.application.service.ReplyFetchService;
 import postman.bottler.reply.application.dto.ReplyType;
 import postman.bottler.reply.application.dto.response.ReplyResponseDTO;
 
@@ -17,7 +15,7 @@ import postman.bottler.reply.application.dto.response.ReplyResponseDTO;
 public class ReplyService {
 
     private final RedisTemplate<String, Object> redisTemplate;
-    private final ReplyRedisService replyRedisService;
+    private final ReplyFetchService replyFetchService;
     private static final int REDIS_SAVED_REPLY = 6;
 
     @Transactional(readOnly = true)
@@ -26,7 +24,7 @@ public class ReplyService {
         List<Object> values = redisTemplate.opsForList().range(key, 0, 2);
 
         if (values == null || values.size() < 3) {
-            replyRedisService.fetchRecentReply(userId);
+            replyFetchService.fetchRecentReply(userId);
             values = redisTemplate.opsForList().range(key, 0, 2);
         }
 

--- a/src/main/java/postman/bottler/reply/application/service/ReplyService.java
+++ b/src/main/java/postman/bottler/reply/application/service/ReplyService.java
@@ -7,6 +7,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import postman.bottler.mapletter.application.service.MapLetterService;
+import postman.bottler.mapletter.application.service.ReplyRedisService;
+import postman.bottler.mapletter.infra.ReplyLetterRedisRepository;
 import postman.bottler.reply.application.dto.ReplyType;
 import postman.bottler.reply.application.dto.response.ReplyResponseDTO;
 
@@ -15,7 +17,7 @@ import postman.bottler.reply.application.dto.response.ReplyResponseDTO;
 public class ReplyService {
 
     private final RedisTemplate<String, Object> redisTemplate;
-    private final MapLetterService mapLetterService;
+    private final ReplyRedisService replyRedisService;
     private static final int REDIS_SAVED_REPLY = 6;
 
     @Transactional(readOnly = true)
@@ -23,10 +25,8 @@ public class ReplyService {
         String key = "REPLY:" + userId;
         List<Object> values = redisTemplate.opsForList().range(key, 0, 2);
 
-        int fetchItemSize = REDIS_SAVED_REPLY - (values == null ? 0 : values.size());
-
         if (values == null || values.size() < 3) {
-            mapLetterService.fetchRecentReply(userId, fetchItemSize);
+            replyRedisService.fetchRecentReply(userId);
             values = redisTemplate.opsForList().range(key, 0, 2);
         }
 


### PR DESCRIPTION
## 📢 기능 설명 
### 지도편지 전체 삭제, 받은 사람 마이페이지에서 삭제 기능 추가

1. 전체 삭제 기능 추가
- SENT(보낸 편지 전체 삭제), SENT-MAP(보낸 지도 편지 삭제), SENT-REPLY(보낸 답장 편지 삭제), RECEIVED(받은 편지 마이페이지에서 삭제), RECEIVED-MAP(받은 지도 편지(타겟으로 받은 편지) 마이페이지에서 삭제), RECEIVED-REPLY(받은 답장 편지 마이페이지에서 삭제) 타입

-----

2. 편지 삭제를 보낸 편지 삭제와 보낸 편지 삭제 API로 분리했습니다. 
- 보낸 편지 삭제는 편지 자체가 soft delete 됩니다.
- 받은 편지 삭제는 편지를 삭제하는 것이 아닌 사용자의 마이페이지에서만 볼 수 없도록 했습니다.
   -  고민했었는데 편지를 만든 사람이 아니기 때문에 편지 자체를 삭제하는 것은 아니라고 판단해서 지도 편지하고 답장 편지에 `isRecipientDeleted` 속성을 추가해서 마이페이지에서 받은 편지 조회시 `isRecipientDeleted`가 true면 조회하지 못하도록 했습니다!
   - 타겟 편지(받은 지도 편지), 받은 답장 편지 모두 받은 사람과 보낸 사람 1:1 관계라서 속성 하나만 추가하는 방향으로 구현했습니다!

---

3. 레디스 코드 infra로 분리
- 책 읽다가... switch-case는 별로라기에 전략 패턴을 도입하려고 했는데 순환참조 오류나서 레디스 코드 별도로 분리했습니다... 근데 전략 패턴은 공부 좀 더 하고 도입해야할거같아서 일단 레디스 코드만 분리해뒀어용

<br>

## 연결된 issue
close #298 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
